### PR TITLE
Make mystery codes optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,67 @@
 # approbation
 Scripts for producing a coverage matrix for Vega [specifications](https://github.com/vegaprotocol/specs)
 
-## Specification file names
-Each protocol specification receives a sequence number when it is merged in to master. 
+```bash
+npx @vegaprotocol/approbation@latest
+```
+
+# Available commands
+
+All of the globs below are relatively simple - check out [globs primer](https://github.com/isaacs/node-glob#glob-primer) for how to get *more* specific (i.e. look for tests that reference only one specification) or less specific (all subfolders).
+ 
+## check-codes
+> Looks for possible errors in the coding of acceptance criteria
+
+**Arguments**
+| **Parameter**   | **Type** | **Description**                      | **Example**          |
+|-----------------|----------|--------------------------------------|----------------------|
+| `--specs`         | glob     | specs to pull AC codes from          | `{specs/**/*.md}`    |
+| `--ignore`        | glob     | glob of files not to check for codes | `specs/0001-spec.md` |
+| `--show-branches` | boolean  | Show git branches for subfolders of the current folder | -  | 
+
+### check-codes example
+```bash
+npx @vegaprotocol/approbation@latest check-filenames --specs="./specs-internal/protocol/**/*.{md,ipynb}" --show-branches 
+```
+
+
+## check-filenames
+> Check that spec filenames are valid
+
+**Arguments**
+| **Parameter**   | **Type** | **Description**                      | **Example**          |
+|-----------------|----------|--------------------------------------|----------------------|
+| `--specs`         | glob     | specs to pull AC codes from          | `{specs/**/*.md}`    |
+| `--ignore`        | glob     | glob of files not to check for codes | `specs/0001-spec.md` |
+| `--show-branches` | boolean  | Show git branches for subfolders of the current folder | -  | 
+
+### check-filenames example
+```bash
+npx @vegaprotocol/approbation@latest check-codes --specs="./specs/protocol/**/*.{md,ipynb}" --tests="./MultisigControl/test/*.js" --ignore="./specs/protocol/{0001-*,0002-*,0004-*}" --show-branches 
+```
+
+
+## check-references
+> Coverage statistics for acceptance criteria
+    
+**Arguments**
+**Arguments**
+| **Parameter**   | **Type** | **Description**                      | **Example**          |
+|-----------------|----------|--------------------------------------|----------------------|
+| `--tests`         | glob     | tests to check for AC codes          | `tests/**/*.{py,feature}`    |
+| `--specs`         | glob     | specs to pull AC codes from          | `{specs/**/*.md}`    |
+| `--ignore`        | glob     | glob of files not to check for codes | `specs/0001-spec.md` |
+| `--show-branches` | boolean  | Show git branches for subfolders of the current folder | -  | 
+| `--show-mystery`  | boolean  | display criteria in tests that are not in any specs matched by `--specs`          | -    |
+
+### check-references example
+```bash
+npx @vegaprotocol/approbation@latest check-references --specs="./specs/protocol/**/*.{md,ipynb}" --tests="./MultisigControl/test/*.js" --ignore="./specs/protocol/{0001-*}" --show-branches --show-mystery
+```
+
+
+# Background
+Each [protocol specification](https://github.com/vegaprotocol/specs) receives a sequence number when it is merged in to master. 
 This sequence number is a 0-padded integer, strictly 1 greater than the last merged 
 specification. The sequence number is the start of the filename, with the end result
 that the `./protocol/` folder lists files in the order they were created.
@@ -46,52 +105,6 @@ writing a test that covers `0008-SYSA-001`, call the feature `Verify blah (0008-
 3. If it covers more than one feature, add it inside the same brackets: `Verify blah (0008-SYSA-001, 0008-SYSA-002)`
 4. If a feature test intentionally covers something that isn't explicitly an acceptance criteria
 you can signal this with `0008-SYSA-additional-tests`
-
-
-# Available checks
-## check-filenames
-Checks that filenames in a given path match the above specification
-
-## check-codes
-Basic checks for codes in specs
-
-## check-references
-Gathers all of the Acceptance Criteria in a given set of specifications, then checks for all of those across a given
-set of tests, to produce a coverage number
-
-# Running these checks
-
-## v2.0.0 onwards
-_All_ checks take a `--specs` argument, which is a [glob](https://www.npmjs.com/package/glob) specifying the specification files to check.
-
-```bash
-npx @vegaprotocol/approbation@latest check-codes --specs='./protocol/*.md'
-```
-
-`check-references` also requires a `--tests` glob, specifying the tests to cross-reference with the `--specs`:
-
-```bash
-npx @vegaprotocol/approbation@latest check-references --specs='./protocol/*.md' --tests='{./feature/*.feature,./system-tests/**/*.py}'
-```
-
-This second example shows how to use globs to specify multiple paths containing tests. For more complex examples, check the 
- [glob](https://www.npmjs.com/package/glob) documentation.
-
-### Defaults
-Default paths will be removed in v3.0.0, but exist in v2.0.0 for legacy support. If not specified, for `check-codes` & `check-filenames`:
-```
---specs='{./non-protocol-specs/**/*.md,./protocol/**/*.md}'
-```
-
-And for `check-references`:
-```
---specs='{./non-protocol-specs/**/*.md,./protocol/**/*.md}'
---tests'{./qa-scenarios/**/*.{feature,py}}'
-  
-```
-
-### show-branches
-Adding `--show-branches` will show the git branch name for each project that is searched for specs/tests. Useful for CI output.
 
 # Development
 Run `npm run setup` to configure your environment:

--- a/bin/approbation.js
+++ b/bin/approbation.js
@@ -15,6 +15,14 @@ function warn (lines) {
   console.warn('')
 }
 
+function showArg (arg, description) {
+  if (description) {
+    console.log(`${pc.bold(arg)}: ${description}`)
+  } else {
+    console.log(`${pc.bold(arg)}`)
+  }
+}
+
 let res
 
 console.log(pc.bold(`Approbation ${packageJson.version}`))
@@ -54,6 +62,7 @@ if (command === 'check-filenames') {
   let specsGlob = '{./non-protocol-specs/**/*.md,./protocol/**/*.md}'
   let testsGlob = '{./qa-scenarios/**/*.{feature,py}}'
   const ignoreGlob = argv.ignore
+  const showMystery = argv['show-mystery'] === true
 
   if (!argv.specs) {
     warn(['No --specs argument provided, defaulting to:', `--specs="${specsGlob}"`, '(This behaviour will be deprecated in 3.0.0)'])
@@ -67,35 +76,45 @@ if (command === 'check-filenames') {
     testsGlob = argv.tests
   }
 
-  res = checkReferences(specsGlob, testsGlob, ignoreGlob)
+  res = checkReferences(specsGlob, testsGlob, ignoreGlob, showMystery)
 
   process.exit(res.exitCode)
 } else {
-  console.error('Please choose a command')
-  console.group('Available commands:')
+  console.error(pc.red(pc.bold('Please choose a command')))
+  console.log()
+  console.group(pc.bold('Available commands:'))
 
-  console.group('check-codes')
+  console.group(pc.bold('check-codes'))
   console.log('Looks for possible errors in the coding of acceptance criteria')
+  console.log()
   console.group('Arguments')
-  console.log('--specs="{**/*.md}"')
-  console.log('--ignore="{**/*.md}"')
+  showArg(`--specs="${pc.yellow('{specs/**/*.md}')}"`, 'glob of specs to pull AC codes from ')
+  showArg(`--ignore="${pc.yellow('tests/**/*.{py,feature}')}"`, 'glob of files not to check for codes')
+  showArg('--show-branches', 'Show git branches for subfolders of the current folder')
   console.groupEnd('Arguments')
   console.groupEnd('check-codes')
 
-  console.group('check-filenames')
+  console.log()
+  console.group(pc.bold('check-filenames'))
   console.log('Check that spec filenames are valid')
+  console.log()
   console.group('Arguments')
-  console.log('--specs="{**/*.md}"')
-  console.log('--ignore="{**/*.md}"')
+  showArg(`--specs="${pc.yellow('{specs/**/*.md}')}"`, 'glob of specs to pull AC codes from ')
+  showArg(`--ignore="${pc.yellow('tests/**/*.{py,feature')}"`, 'glob of filenames to ignore')
+  showArg('--show-branches', 'Show git branches for subfolders of the current folder')
   console.groupEnd('Arguments')
   console.groupEnd('check-filenames')
 
-  console.group('check-references')
+  console.log()
+  console.group(pc.bold('check-references'))
   console.log('Coverage statistics for acceptance criteria')
+  console.log()
   console.group('Arguments')
-  console.log('--specs="{specs/**/*.md}"')
-  console.log('--tests="tests/**/*.{py,feature}"')
-  console.log('--ignore="tests/**/*.{py,feature}"')
+  showArg(`--specs="${pc.yellow('{specs/**/*.md}')}"`, 'glob of specs to pull AC codes from ')
+  showArg(`--tests="${pc.yellow('tests/**/*.{py,feature}')}"`, 'glob of tests to match to the spec AC codes')
+  showArg(`--ignore="${pc.yellow('{tests/**/*.{py,feature}')}"`, 'glob of files to ignore for both tests and specs')
+  showArg('--show-mystery', 'If set, display criteria in tests that are not in any specs matched by --specs')
+  showArg('--show-branches', 'Show git branches for subfolders of the current folder')
   console.groupEnd('Arguments')
   console.groupEnd('check-references')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Match Acceptance Criteria Codes with the tests that test them",
   "main": "./bin/approbation.js",
   "engine": ">= 16",

--- a/src/check-references.js
+++ b/src/check-references.js
@@ -136,7 +136,7 @@ function processReferences (specs, tests) {
   }
 }
 
-function checkReferences (specsGlob, testsGlob, ignoreGlob) {
+function checkReferences (specsGlob, testsGlob, ignoreGlob, showMystery = false) {
   const ignoreList = ignoreGlob ? glob.sync(ignoreGlob, {}) : []
   const specList = ignoreFiles(glob.sync(specsGlob, {}), ignoreList)
   const testList = ignoreFiles(glob.sync(testsGlob, {}), ignoreList, 'test')
@@ -163,7 +163,7 @@ function checkReferences (specsGlob, testsGlob, ignoreGlob) {
     const criteriaReferencedPercent = Math.round(criteriaReferencedTotal / criteriaTotal * 100)
     const criteriaUnreferencedPercent = Math.round(criteriaUnreferencedTotal / criteriaTotal * 100)
 
-    if (unknownCriteriaInTests.size > 0) {
+    if (showMystery && unknownCriteriaInTests.size > 0) {
       const g = pc.bold(`${pc.red('Mystery criteria')} referenced in tests, not found in specs:`)
       console.group(g)
       console.dir(unknownCriteriaInTests)
@@ -174,7 +174,10 @@ function checkReferences (specsGlob, testsGlob, ignoreGlob) {
     console.log(pc.bold('Total criteria') + `:       ${criteriaTotal}`)
     console.log(pc.green(pc.bold('With references')) + `:      ${criteriaReferencedTotal} (${criteriaReferencedPercent}%)`)
     console.log(pc.red(pc.bold('Without references')) + `:   ${criteriaUnreferencedTotal} (${criteriaUnreferencedPercent}%)`)
-    console.log(pc.red(pc.bold('Mystery criteria')) + `:     ${unknownCriteriaInTests.size}`)
+
+    if (showMystery) {
+      console.log(pc.red(pc.bold('Mystery criteria')) + `:     ${unknownCriteriaInTests.size}`)
+    }
 
     return {
       exitCode,


### PR DESCRIPTION
check-references started showing 'mystery' codes by default, which is confusing when you are
running it on a subset of specs. This PR makes it an optional parameter

- Add `--show-mystery` parameter
- Update documentation 

Closes #30
