### PR TITLE
Add categories support

### DIFF
--- a/bin/approbation.js
+++ b/bin/approbation.js
@@ -49,6 +49,7 @@ if (command === 'check-filenames') {
 } else if (command === 'check-codes') {
   let paths = '{./non-protocol-specs/**/*.md,./protocol/**/*.md}'
   const ignoreGlob = argv.ignore
+  const isVerbose = argv.verbose === true
 
   if (!argv.specs) {
     warn(['No --specs argument provided, defaulting to:', `--specs="${paths}"`, '(This behaviour will be deprecated in 3.0.0)'])
@@ -56,13 +57,16 @@ if (command === 'check-filenames') {
     paths = argv.specs
   }
 
-  res = checkCodes(paths, ignoreGlob)
+  res = checkCodes(paths, ignoreGlob, isVerbose)
   process.exit(res.exitCode)
 } else if (command === 'check-references') {
   let specsGlob = '{./non-protocol-specs/**/*.md,./protocol/**/*.md}'
   let testsGlob = '{./qa-scenarios/**/*.{feature,py}}'
   const ignoreGlob = argv.ignore
   const showMystery = argv['show-mystery'] === true
+  const showCategoryStats = argv['category-stats'] === true
+  const isVerbose = argv.verbose === true
+  const showFiles = argv['show-files'] === true
 
   if (!argv.specs) {
     warn(['No --specs argument provided, defaulting to:', `--specs="${specsGlob}"`, '(This behaviour will be deprecated in 3.0.0)'])
@@ -76,7 +80,7 @@ if (command === 'check-filenames') {
     testsGlob = argv.tests
   }
 
-  res = checkReferences(specsGlob, testsGlob, ignoreGlob, showMystery)
+  res = checkReferences(specsGlob, testsGlob, ignoreGlob, showMystery, isVerbose, showCategoryStats, showFiles)
 
   process.exit(res.exitCode)
 } else {
@@ -90,6 +94,7 @@ if (command === 'check-filenames') {
   console.group('Arguments')
   showArg(`--specs="${pc.yellow('{specs/**/*.md}')}"`, 'glob of specs to pull AC codes from ')
   showArg(`--ignore="${pc.yellow('tests/**/*.{py,feature}')}"`, 'glob of files not to check for codes')
+  showArg('--verbose', 'Show more detail for referenced/unreferenced codes')
   showArg('--show-branches', 'Show git branches for subfolders of the current folder')
   console.groupEnd('Arguments')
   console.groupEnd('check-codes')
@@ -114,7 +119,10 @@ if (command === 'check-filenames') {
   showArg(`--tests="${pc.yellow('tests/**/*.{py,feature}')}"`, 'glob of tests to match to the spec AC codes')
   showArg(`--ignore="${pc.yellow('{tests/**/*.{py,feature}')}"`, 'glob of files to ignore for both tests and specs')
   showArg('--show-mystery', 'If set, display criteria in tests that are not in any specs matched by --specs')
+  showArg('--category-stats', 'Show more detail for referenced/unreferenced codes')
   showArg('--show-branches', 'Show git branches for subfolders of the current folder')
+  showArg('--show-files', 'Show basic stats per file')
+  showArg('--verbose', 'Show more detail for each file')
   console.groupEnd('Arguments')
   console.groupEnd('check-references')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "2.3.0",
+  "version": "2.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vegaprotocol/approbation",
-      "version": "2.3.0",
+      "version": "2.3.4",
       "license": "Unlicense",
       "dependencies": {
+        "git-rev-sync": "3.0.2",
         "glob": "^7.2.0",
         "minimist": "^1.2.5",
         "picocolors": "^1.0.0"
@@ -17,7 +18,6 @@
         "approbation": "bin/approbation.js"
       },
       "devDependencies": {
-        "git-rev-sync": "3.0.2",
         "husky": "7.0.4",
         "standard": "16.0.4",
         "tap-arc": "0.1.2",
@@ -606,7 +606,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1162,8 +1161,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -1226,7 +1224,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-3.0.2.tgz",
       "integrity": "sha512-Nd5RiYpyncjLv0j6IONy0lGzAqdRXUaBctuGBbrEA2m6Bn4iDrN/9MeQTXuiquw8AEKL9D2BW0nw5m/lQvxqnQ==",
-      "dev": true,
       "dependencies": {
         "escape-string-regexp": "1.0.5",
         "graceful-fs": "4.1.15",
@@ -1282,14 +1279,12 @@
     "node_modules/graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -1442,7 +1437,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -1513,7 +1507,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2159,8 +2152,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "3.0.0",
@@ -2397,7 +2389,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
       "dependencies": {
         "resolve": "^1.1.6"
       },
@@ -2446,7 +2437,6 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -2552,7 +2542,6 @@
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -2833,7 +2822,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3648,8 +3636,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "7.18.0",
@@ -4071,8 +4058,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -4117,7 +4103,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-3.0.2.tgz",
       "integrity": "sha512-Nd5RiYpyncjLv0j6IONy0lGzAqdRXUaBctuGBbrEA2m6Bn4iDrN/9MeQTXuiquw8AEKL9D2BW0nw5m/lQvxqnQ==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5",
         "graceful-fs": "4.1.15",
@@ -4158,14 +4143,12 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -4269,8 +4252,7 @@
     "interpret": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "is-arguments": {
       "version": "1.1.1",
@@ -4317,7 +4299,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -4794,8 +4775,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "3.0.0",
@@ -4977,7 +4957,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -5008,7 +4987,6 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -5073,7 +5051,6 @@
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -5268,8 +5245,7 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "table": {
       "version": "6.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.4",
       "license": "Unlicense",
       "dependencies": {
+        "console-table-printer": "^2.10.0",
         "git-rev-sync": "3.0.2",
         "glob": "^7.2.0",
         "minimist": "^1.2.5",
@@ -393,6 +394,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/console-table-printer": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.10.0.tgz",
+      "integrity": "sha512-7pTsysaJs1+R+OO4cCtJbl+Lr4piHYIhi7/V1qHbOg/uiYgq2yUINFgvXZtVHqm9qpW0+Uk190qkGcKvzdunvg==",
+      "dependencies": {
+        "simple-wcswidth": "^1.0.1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2568,6 +2577,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-wcswidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
+      "integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg=="
+    },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -3461,6 +3475,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-table-printer": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.10.0.tgz",
+      "integrity": "sha512-7pTsysaJs1+R+OO4cCtJbl+Lr4piHYIhi7/V1qHbOg/uiYgq2yUINFgvXZtVHqm9qpW0+Uk190qkGcKvzdunvg==",
+      "requires": {
+        "simple-wcswidth": "^1.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -5067,6 +5089,11 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "simple-wcswidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
+      "integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg=="
     },
     "slice-ansi": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "Match Acceptance Criteria Codes with the tests that test them",
   "main": "./bin/approbation.js",
   "engine": ">= 16",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "tape": "5.5.2"
   },
   "dependencies": {
+    "console-table-printer": "^2.10.0",
     "git-rev-sync": "3.0.2",
     "glob": "^7.2.0",
     "minimist": "^1.2.5",

--- a/src/check-codes.js
+++ b/src/check-codes.js
@@ -65,7 +65,7 @@ function findDuplicates (codes) {
 }
 
 // Outputs acceptance criteria count if it's acceptable
-const isVerbose = false
+let verbose = false
 
 function checkPath (files) {
   // The number of files that appear to have 0 acceptance criteria
@@ -131,7 +131,7 @@ function checkPath (files) {
       // The files are *valid*, at least. But do they have enough ACs?
       if (totalAcceptanceCriteria.length >= minimumAcceptableACsPerSpec) {
         countAcceptableFiles++
-        if (isVerbose) {
+        if (verbose) {
           console.group(file)
           console.log(`${totalAcceptanceCriteria.length} acceptance criteria`)
         }
@@ -153,7 +153,8 @@ function checkPath (files) {
   }
 }
 
-function checkCodes (paths, ignoreGlob) {
+function checkCodes (paths, ignoreGlob, isVerbose = false) {
+  verbose = isVerbose
   const ignoreList = ignoreGlob ? glob.sync(ignoreGlob, {}) : []
   const fileList = ignoreFiles(glob.sync(paths, {}), ignoreList)
   let exitCode = 0

--- a/src/check-references.js
+++ b/src/check-references.js
@@ -244,12 +244,12 @@ function checkReferences (specsGlob, testsGlob, ignoreGlob, showMystery = false,
           Category: pc.yellow(key),
           'Spec files': c.specCount || pc.gray('-'),
           'Acceptable': c.acceptableSpecCount ? c.acceptableSpecCount === c.specCount ? pc.green(c.acceptableSpecCount) : pc.red(c.acceptableSpecCount) : pc.gray('-'),
-          'AC codes': c.codes || pc.gray('-'),
-          'ACs covered': c.covered || pc.gray('-'),
-          'ACs/Features': c.featureCovered || pc.gray('-'),
-          'ACs/Systest': c.systemTestCovered || pc.gray('-'),
-          'ACs uncovered': c.uncovered || pc.gray('-'),
-          'AC coverage': isNaN(coverage) ? '-' : `${coverage}%`
+          'Total ACs': c.codes || pc.gray('-'),
+          'ACs w/FeatTest': c.featureCovered || pc.gray('-'),
+          'ACs w/SysTest': c.systemTestCovered || pc.gray('-'),
+          'ACs Covered': c.covered || pc.gray('-'),
+          'ACs Not Covered': c.uncovered || pc.gray('-'),
+          'AC Coverage %': isNaN(coverage) ? '-' : `${coverage}%`
         }
       })
 
@@ -257,12 +257,12 @@ function checkReferences (specsGlob, testsGlob, ignoreGlob, showMystery = false,
         Category: pc.bold(pc.yellow('Total')),
         'Spec files': pc.yellow(specFilesTotal),
         'Acceptable': pc.yellow(acceptableSpecsTotal),
-        'AC codes': pc.yellow(criteriaTotal),
-        'ACs covered': pc.yellow(criteriaReferencedTotal),
-        'ACs/Features': pc.yellow(labelledFeatureTotal),
-        'ACs/Systest': pc.yellow(labelledSystestTotal),
-        'ACs uncovered': pc.yellow(criteriaUnreferencedTotal),
-        'AC coverage': pc.yellow(`${criteriaReferencedPercent}%`)
+        'Total ACs': pc.yellow(criteriaTotal),
+        'ACs Covered': pc.yellow(criteriaReferencedTotal),
+        'ACs w/FeatTest': pc.yellow(labelledFeatureTotal),
+        'ACs w/SysTest': pc.yellow(labelledSystestTotal),
+        'ACs Not Covered': pc.yellow(criteriaUnreferencedTotal),
+        'AC Coverage %': pc.yellow(`${criteriaReferencedPercent}%`)
       })
 
       printTable(categories)

--- a/src/check-references.js
+++ b/src/check-references.js
@@ -288,7 +288,7 @@ function checkReferences (specsGlob, testsGlob, ignoreGlob, showMystery = false,
     }
 
     if (testList === 0) {
-      console.error(pc.red(`--tets matched no files (${testsGlob}})`))
+      console.error(pc.red(`--tests matched no files (${testsGlob}})`))
     } else {
       console.error(pc.red(`--tests matched ${pc.bold(testList.length)} files (${pc.dim(testsGlob)})`))
     }

--- a/src/lib/category.js
+++ b/src/lib/category.js
@@ -3,19 +3,19 @@ const specCategories = {
      'specs': ['0017-PART', '0022-AUTH', '0051-PROD', '0016-PFUT', '0053-PERP', '0040-ASSF', '0013-ACCT', '0028-GOVE', '0054-NETP', '0068-MATC', '0067-KEYS', '0057-TRAN', '0052-FPOS']
    },
    'Markets': {
-     'specs': ['0043-MKTL', '0026-AUCT', '0006-POSI', '0008-TRAD', '0001-MKTF', '0009-MRKP', '0012-POSR', '0021-MDAT', '0039-MKTD', '0070-MKTD']
+     'specs': ['0035-LIQM', '0032-PRIM', '0043-MKTL', '0026-AUCT', '0006-POSI', '0008-TRAD', '0001-MKTF', '0009-MRKP', '0012-POSR', '0021-MDAT', '0039-MKTD', '0070-MKTD']
    },
    'Settlement': {
      'specs': ['0002-STTL', '0003-MTMK']
    },
    'Protections': {
-     'specs': ['0032-PRIM', '0035-LIQM', '0062-SPAM', '0060-WEND', '0003-NP-LIMI', '0005-NP-LIMN']
+     'specs': ['0062-SPAM', '0060-WEND', '0003-NP-LIMI', '0005-NP-LIMN']
    },
    'Liquidity': {
      'specs': ['0044-LIQM', '0042-LIQF', '0034-PROB']
    },
    'Governance': {
-     'specs': ['0028-GOVE', '0027-ASSP', '0061-REWP', '0059-STKG', '0058-REWS', '0056-REWA', '0055-TREA']
+     'specs': ['0028-GOVE', '0027-ASSP', '0059-STKG', '0058-REWS', '0056-REWA', '0055-TREA']
    },
    'Orders': {
      'specs': ['0014-ORDT', '0004-AMND', '0024-OSTA', '0025-OCRE', '0037-OPEG', '0033-OCAN', '0038-OLIQ']
@@ -30,12 +30,12 @@ const specCategories = {
      'specs': ['0049-TVAL', '0050-EPOC', '0030-ETHM', '0031-ETHB']
    },
    'Staking & Validators': {
-     'specs': ['0059-STKG', '0056-REWA', '0058-REWS', '0055-TREA', '0041-TSTK', '0069-VCBS', '0066-VALW', '0065-FTCO', '0064-VALP', '0063-VALK']
+     'specs': ['0059-STKG', '0056-REWA', '0061-REWP', '0058-REWS', '0055-TREA', '0041-TSTK', '0069-VCBS', '0066-VALW', '0065-FTCO', '0064-VALP', '0063-VALK']
    },
    'Architecture': {
      'specs': ['0036-BRIE', '0009-NP-SNAP']
    },
-   'Tools': {
+   'Data': {
      'specs': ['0020-APIS', '0007-POSN']
    },
    'Unknown': {

--- a/src/lib/category.js
+++ b/src/lib/category.js
@@ -1,3 +1,4 @@
+// This should be committed as a JSON file to the specs repo - but for now, this will do
 const specCategories = {
    'Fundamentals': {
      'specs': ['0017-PART', '0022-AUTH', '0051-PROD', '0016-PFUT', '0053-PERP', '0040-ASSF', '0013-ACCT', '0028-GOVE', '0054-NETP', '0068-MATC', '0067-KEYS', '0057-TRAN', '0052-FPOS']

--- a/src/lib/category.js
+++ b/src/lib/category.js
@@ -27,10 +27,10 @@ const specCategories = {
      'specs': ['0045-DSRC', '0046-DSRM', '0047-DSRF', '0048-DSRI']
    },
    'Bridges': {
-     'specs': ['0049-TVAL', '0050-EPOC', '0030-ETHM', '0031-ETHB', '0069-VCBS', '0066-VALW', '0065-FTCO', '0064-VALP', '0063-VALK']
+     'specs': ['0049-TVAL', '0050-EPOC', '0030-ETHM', '0031-ETHB']
    },
-   'Staking': {
-     'specs': ['0059-STKG', '0056-REWA', '0058-REWS', '0055-TREA', '0041-TSTK']
+   'Staking & Validators': {
+     'specs': ['0059-STKG', '0056-REWA', '0058-REWS', '0055-TREA', '0041-TSTK', '0069-VCBS', '0066-VALW', '0065-FTCO', '0064-VALP', '0063-VALK']
    },
    'Architecture': {
      'specs': ['0036-BRIE', '0009-NP-SNAP']
@@ -53,7 +53,6 @@ function getCategoryForSpec(code) {
 }
 
 function setOrIncreaseProperty(category, property, value) {
-  console.log(category, property, value)
 
   if (specCategories[category][property]) {
     specCategories[category][property] += value
@@ -70,10 +69,25 @@ function increaseCoveredForCategory(category, count) {
   setOrIncreaseProperty(category, 'covered', count)
 }
 
+function increaseFeatureCoveredForCategory(category, count) {
+  setOrIncreaseProperty(category, 'featureCovered', count)
+}
+
+function increaseSystemTestCoveredForCategory(category, count) {
+  setOrIncreaseProperty(category, 'systemTestCovered', count)
+}
+
 function increaseUncoveredForCategory(category, count) {
   setOrIncreaseProperty(category, 'uncovered', count)
 }
 
+function increaseSpecCountForCategory(category) {
+  setOrIncreaseProperty(category, 'specCount', 1)
+}
+
+function increaseAcceptableSpecsForCategory(category) {
+  setOrIncreaseProperty(category, 'acceptableSpecCount', 1)
+}
 
 module.exports = {
   specCategories,
@@ -81,4 +95,8 @@ module.exports = {
   increaseCodesForCategory,
   increaseCoveredForCategory,
   increaseUncoveredForCategory,
+  increaseSpecCountForCategory,
+  increaseSystemTestCoveredForCategory,
+  increaseFeatureCoveredForCategory,
+  increaseAcceptableSpecsForCategory
 }

--- a/src/lib/category.js
+++ b/src/lib/category.js
@@ -1,0 +1,84 @@
+const specCategories = {
+   'Fundamentals': {
+     'specs': ['0017-PART', '0022-AUTH', '0051-PROD', '0016-PFUT', '0053-PERP', '0040-ASSF', '0013-ACCT', '0028-GOVE', '0054-NETP', '0068-MATC', '0067-KEYS', '0057-TRAN', '0052-FPOS']
+   },
+   'Markets': {
+     'specs': ['0043-MKTL', '0026-AUCT', '0006-POSI', '0008-TRAD', '0001-MKTF', '0009-MRKP', '0012-POSR', '0021-MDAT', '0039-MKTD', '0070-MKTD']
+   },
+   'Settlement': {
+     'specs': ['0002-STTL', '0003-MTMK']
+   },
+   'Protections': {
+     'specs': ['0032-PRIM', '0035-LIQM', '0062-SPAM', '0060-WEND', '0003-NP-LIMI', '0005-NP-LIMN']
+   },
+   'Liquidity': {
+     'specs': ['0044-LIQM', '0042-LIQF', '0034-PROB']
+   },
+   'Governance': {
+     'specs': ['0028-GOVE', '0027-ASSP', '0061-REWP', '0059-STKG', '0058-REWS', '0056-REWA', '0055-TREA']
+   },
+   'Orders': {
+     'specs': ['0014-ORDT', '0004-AMND', '0024-OSTA', '0025-OCRE', '0037-OPEG', '0033-OCAN', '0038-OLIQ']
+   },
+   'Margin': {
+     'specs': ['0029-FEES', '0005-COLL', '0010-MARG', '0011-MARA', '0015-INSR', '0019-MCAL', '0018-RSKM', '0023-CALI']
+   },
+   'Oracles': {
+     'specs': ['0045-DSRC', '0046-DSRM', '0047-DSRF', '0048-DSRI']
+   },
+   'Bridges': {
+     'specs': ['0049-TVAL', '0050-EPOC', '0030-ETHM', '0031-ETHB', '0069-VCBS', '0066-VALW', '0065-FTCO', '0064-VALP', '0063-VALK']
+   },
+   'Staking': {
+     'specs': ['0059-STKG', '0056-REWA', '0058-REWS', '0055-TREA', '0041-TSTK']
+   },
+   'Architecture': {
+     'specs': ['0036-BRIE', '0009-NP-SNAP']
+   },
+   'Tools': {
+     'specs': ['0020-APIS', '0007-POSN']
+   },
+   'Unknown': {
+     'specs': []
+   }
+}
+
+function getCategoryForSpec(code) {
+  const categories = Object.keys(specCategories).filter(category => {
+    return (specCategories[category].specs.indexOf(code) !== -1)
+  })
+
+  // There shouldn't be more than one. But if there is, take the first one.
+  return (categories.length > 0) ? categories[0] : 'Unknown'
+}
+
+function setOrIncreaseProperty(category, property, value) {
+  console.log(category, property, value)
+
+  if (specCategories[category][property]) {
+    specCategories[category][property] += value
+  } else {
+    specCategories[category][property] = value
+  }
+}
+
+function increaseCodesForCategory(category, count) {
+  setOrIncreaseProperty(category, 'codes', count)
+}
+
+function increaseCoveredForCategory(category, count) {
+  setOrIncreaseProperty(category, 'covered', count)
+}
+
+function increaseUncoveredForCategory(category, count) {
+  setOrIncreaseProperty(category, 'uncovered', count)
+}
+
+
+module.exports = {
+  specCategories,
+  getCategoryForSpec,
+  increaseCodesForCategory,
+  increaseCoveredForCategory,
+  increaseUncoveredForCategory,
+}


### PR DESCRIPTION
Batch specs in to categories, and tally some data for those categories

WIP currently: output is messy, code is messy, data is functional at least 🤷 

```
Fundamentals
  Total ACs: 168
  Covered ACs: 69
  Uncovered ACs: 99
Markets
  Total ACs: 78
  Covered ACs: 12
  Uncovered ACs: 66
Settlement
  Total ACs: 21
  Covered ACs: 8
  Uncovered ACs: 13
Protections
  Total ACs: 47
  Covered ACs: 0
  Uncovered ACs: 47
Liquidity
  Total ACs: 19
  Covered ACs: 5
  Uncovered ACs: 14
Governance
  Total ACs: 48
  Covered ACs: 14
  Uncovered ACs: 34
Orders
  Total ACs: 58
  Covered ACs: 39
  Uncovered ACs: 19
Margin
  Total ACs: 51
  Covered ACs: 17
  Uncovered ACs: 34
Oracles
  Total ACs: 63
  Covered ACs: 0
  Uncovered ACs: 63
Bridges
  Total ACs: 71
  Covered ACs: 25
  Uncovered ACs: 46
Staking
  Total ACs: 3
  Covered ACs: 1
  Uncovered ACs: 2
Architecture
  Total ACs: 19
  Covered ACs: 0
  Uncovered ACs: 19
Tools
  Total ACs: 22
  Covered ACs: 0
  Uncovered ACs: 22
```


Closes #32 