### PR TITLE
chore: update version before tagging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Match Acceptance Criteria Codes with the tests that test them",
   "main": "./bin/approbation.js",
   "engine": ">= 16",


### PR DESCRIPTION
Update the version, once merged I can:

- create a new tag
- merge https://github.com/vegaprotocol/jenkins-shared-library/pull/156
- check the coverage run picks up categories