### PR TITLE
chore: update 0044 `LIQM` to `LIME` in category.js

### DIFF
--- a/src/lib/category.js
+++ b/src/lib/category.js
@@ -13,7 +13,7 @@ const specCategories = {
      'specs': ['0073-LIMN', '0072-SPPW', '0062-SPAM', '0060-WEND', '0003-NP-LIMI']
    },
    'Liquidity': {
-     'specs': ['0044-LIQM', '0042-LIQF', '0034-PROB']
+     'specs': ['0044-LIME', '0042-LIQF', '0034-PROB']
    },
    'Governance': {
      'specs': ['0028-GOVE', '0027-ASSP', '0059-STKG', '0058-REWS', '0056-REWA', '0055-TREA']


### PR DESCRIPTION
The part of that I forgot to update:
- https://github.com/vegaprotocol/specs/pull/1166

In order to resolve the duplicate AC Code it was renamed in a spec file and associated links. This PR ensure the coverage report places it in the correct category.