### PR TITLE
chore: update spec names after directory move

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Match Acceptance Criteria Codes with the tests that test them",
   "main": "./bin/approbation.js",
   "engine": ">= 16",

--- a/src/lib/category.js
+++ b/src/lib/category.js
@@ -31,10 +31,10 @@ const specCategories = {
      'specs': ['0071-STAK', '0059-STKG', '0056-REWA', '0061-REWP', '0058-REWS', '0055-TREA', '0041-TSTK', '0069-VCBS', '0066-VALW', '0065-FTCO', '0064-VALP', '0063-VALK']
    },
    'Architecture': {
-     'specs': ['0036-BRIE', '0009-NP-SNAP', '0075-PLUP']
+     'specs': ['0036-BRIE', '0077-SNAP', '0075-PLUP']
    },
    'Data': {
-     'specs': ['0011-NP-DANO', '0020-APIS', '0007-POSN']
+     'specs': ['0076-DANO', '0020-APIS', '0007-POSN']
    },
    'UI': {
      'specs': ['1000-ASSO', '1001-VEST', '1002-STAK', '1003-INCO', '1004-VOTE', '1005-PROP', '1006-NETW', '1007-WALL', '3000-DEPO', '3001-WITH', '5000-MARK', '6000-COLL', '6001-SORD', '6002-MORD', '6003-POSI', '6004-FILL']

--- a/src/lib/priority.js
+++ b/src/lib/priority.js
@@ -4,8 +4,11 @@ const specPriorities = {
   '0022-AUTH': 1,
   '0066-VALW': 1,
   '0069-VCBS': 1,
-  '0009-NP-SNAP': 1,
+  '0077-SNAP': 1,
   '0073-LIMN': 1,
+  '0074-BTCH': 1,
+  '0075-PLUP': 1,
+  '0076-DANO': 1,
   // ==============
   '0006-POSI': 2,
   '0008-TRAD': 2,
@@ -26,8 +29,6 @@ const specPriorities = {
   '0064-VALP': 2,
   '0067-KEYS': 2,
   '0072-SPPW': 2,
-  '0074-BTCH': 2,
-  '0075-PLUP': 2,
   // ==============
   '0017-PART': 3,
   '0025-OCRE': 3,


### PR DESCRIPTION
Bumps version and renames now that specs moved from non-protocol to protocol folders

resolves vegaprotocol/specs#1282

DO NOT MEREGE UNTIL THIS HAS BEEN:
- https://github.com/vegaprotocol/specs/pull/1283