### PR TITLE
Externalise categories

### DIFF
--- a/bin/approbation.js
+++ b/bin/approbation.js
@@ -60,8 +60,9 @@ if (command === 'check-filenames') {
   res = checkCodes(paths, ignoreGlob, isVerbose)
   process.exit(res.exitCode)
 } else if (command === 'check-references') {
-  let specsGlob = '{./non-protocol-specs/**/*.md,./protocol/**/*.md}'
-  let testsGlob = '{./qa-scenarios/**/*.{feature,py}}'
+  let specsGlob = argv['specs']
+  let testsGlob = argv['tests']
+  const categories = argv['categories']
   const ignoreGlob = argv.ignore
   const showMystery = argv['show-mystery'] === true
   const showCategoryStats = argv['category-stats'] === true
@@ -72,19 +73,22 @@ if (command === 'check-filenames') {
   const shouldShowFileStats = argv['show-file-stats'] === true
 
   if (!argv.specs) {
-    warn(['No --specs argument provided, defaulting to:', `--specs="${specsGlob}"`, '(This behaviour will be deprecated in 3.0.0)'])
-  } else {
-    specsGlob = argv.specs
+    warn(['No --specs argument provided, exiting'])
+    process.exit(1)
   }
 
   if (!argv.tests) {
-    warn(['No --tests argument provided, defaulting to:', `--specs="${testsGlob}"`, '(This behaviour will be deprecated in 3.0.0)'])
-  } else {
-    testsGlob = argv.tests
+    warn(['No --tests argument provided, exiting'])
+    process.exit(1)
+  }
+
+  if (!categories) {
+    warn(['No --categories argument provided, exiting'])
+    process.exit(1)
   }
 
   // TODO: Turn in to an object
-  res = checkReferences(specsGlob, testsGlob, ignoreGlob, showMystery, isVerbose, showCategoryStats, showFiles, shouldOutputCSV, shouldOutputJenkins, shouldShowFileStats)
+  res = checkReferences(specsGlob, testsGlob, categories, ignoreGlob, showMystery, isVerbose, showCategoryStats, showFiles, shouldOutputCSV, shouldOutputJenkins, shouldShowFileStats)
 
   process.exit(res.exitCode)
 } else {
@@ -121,6 +125,7 @@ if (command === 'check-filenames') {
   console.group('Arguments')
   showArg(`--specs="${pc.yellow('{specs/**/*.md}')}"`, 'glob of specs to pull AC codes from ')
   showArg(`--tests="${pc.yellow('tests/**/*.{py,feature}')}"`, 'glob of tests to match to the spec AC codes')
+  showArg(`--categories="${pc.yellow('./specs/protocol/categories.json')}"`, 'Single JSON file that contains the categories for this test run')
   showArg(`--ignore="${pc.yellow('{tests/**/*.{py,feature}')}"`, 'glob of files to ignore for both tests and specs')
   showArg('--show-mystery', 'If set, display criteria in tests that are not in any specs matched by --specs')
   showArg('--category-stats', 'Show more detail for referenced/unreferenced codes')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "2.7.1",
+  "version": "3.0.0",
   "description": "Match Acceptance Criteria Codes with the tests that test them",
   "main": "./bin/approbation.js",
   "engine": ">= 16",

--- a/src/lib/category.js
+++ b/src/lib/category.js
@@ -1,50 +1,26 @@
 // This should be committed as a JSON file to the specs repo - but for now, this will do
-const specCategories = {
-   'Fundamentals': {
-     'specs': ['0017-PART', '0022-AUTH', '0051-PROD', '0016-PFUT', '0053-PERP', '0040-ASSF', '0013-ACCT', '0028-GOVE', '0054-NETP', '0068-MATC', '0067-KEYS', '0057-TRAN', '0052-FPOS']
-   },
-   'Markets': {
-     'specs': ['0035-LIQM', '0032-PRIM', '0043-MKTL', '0026-AUCT', '0006-POSI', '0008-TRAD', '0001-MKTF', '0009-MRKP', '0012-POSR', '0021-MDAT', '0039-MKTD', '0070-MKTD']
-   },
-   'Settlement & Oracles': {
-     'specs': ['0002-STTL', '0003-MTMK', '0045-DSRC', '0046-DSRM', '0047-DSRF', '0048-DSRI']
-   },
-   'Protections': {
-     'specs': ['0073-LIMN', '0072-SPPW', '0062-SPAM', '0060-WEND', '0003-NP-LIMI', '0072-SPPW']
-   },
-   'Liquidity': {
-     'specs': ['0044-LIME', '0042-LIQF', '0034-PROB']
-   },
-   'Governance': {
-     'specs': ['0028-GOVE', '0027-ASSP', '0059-STKG', '0058-REWS', '0056-REWA', '0055-TREA']
-   },
-   'Orders': {
-     'specs': ['0014-ORDT', '0004-AMND', '0024-OSTA', '0025-OCRE', '0037-OPEG', '0033-OCAN', '0038-OLIQ', '0074-BTCH']
-   },
-   'Margin': {
-     'specs': ['0029-FEES', '0005-COLL', '0010-MARG', '0011-MARA', '0015-INSR', '0019-MCAL', '0018-RSKM', '0023-CALI']
-   },
-   'Bridges': {
-     'specs': ['0049-TVAL', '0050-EPOC', '0030-ETHM', '0031-ETHB']
-   },
-   'Staking & Validators': {
-     'specs': ['0071-STAK', '0059-STKG', '0056-REWA', '0061-REWP', '0058-REWS', '0055-TREA', '0041-TSTK', '0069-VCBS', '0066-VALW', '0065-FTCO', '0064-VALP', '0063-VALK']
-   },
-   'Architecture': {
-     'specs': ['0036-BRIE', '0077-SNAP', '0075-PLUP']
-   },
-   'Data': {
-     'specs': ['0076-DANO', '0020-APIS', '0007-POSN']
-   },
-   'UI': {
-     'specs': ['1000-ASSO', '1001-VEST', '1002-STAK', '1003-INCO', '1004-VOTE', '1005-PROP', '1006-NETW', '1007-WALL', '3000-DEPO', '3001-WITH', '5000-MARK', '6000-COLL', '6001-SORD', '6002-MORD', '6003-POSI', '6004-FILL']
-   },
-   'Unknown': {
-     'specs': []
-   }
+const ErrorCategoriesEmpty = new Error('Categories have not been set')
+let specCategories
+
+function isCategoriesEmpty() {
+  if (specCategories === undefined) {
+    throw ErrorCategoriesEmpty
+  }
+  return Object.keys(specCategories).length === 0 
+}
+
+function setCategories(categories) {
+  specCategories = categories
+  if (!specCategories['Unknown']) {
+    specCategories['Unknown'] = { specs: [], specCount: 0 }
+  }
 }
 
 function getCategoryForSpec(code) {
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  }
+
   const categories = Object.keys(specCategories).filter(category => {
     return (specCategories[category].specs.indexOf(code) !== -1)
   })
@@ -54,7 +30,10 @@ function getCategoryForSpec(code) {
 }
 
 function setOrIncreaseProperty(category, property, value) {
-
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  }
+  
   if (specCategories[category][property]) {
     specCategories[category][property] += value
   } else {
@@ -63,30 +42,51 @@ function setOrIncreaseProperty(category, property, value) {
 }
 
 function increaseCodesForCategory(category, count) {
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  }
   setOrIncreaseProperty(category, 'codes', count)
 }
 
 function increaseCoveredForCategory(category, count) {
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  }  
   setOrIncreaseProperty(category, 'covered', count)
 }
 
 function increaseFeatureCoveredForCategory(category, count) {
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  } 
   setOrIncreaseProperty(category, 'featureCovered', count)
 }
 
 function increaseSystemTestCoveredForCategory(category, count) {
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  } 
   setOrIncreaseProperty(category, 'systemTestCovered', count)
 }
 
 function increaseUncoveredForCategory(category, count) {
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  } 
   setOrIncreaseProperty(category, 'uncovered', count)
 }
 
 function increaseSpecCountForCategory(category) {
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  } 
   setOrIncreaseProperty(category, 'specCount', 1)
 }
 
 function increaseAcceptableSpecsForCategory(category) {
+  if (isCategoriesEmpty()) {
+    throw ErrorCategoriesEmpty
+  } 
   setOrIncreaseProperty(category, 'acceptableSpecCount', 1)
 }
 
@@ -99,5 +99,6 @@ module.exports = {
   increaseSpecCountForCategory,
   increaseSystemTestCoveredForCategory,
   increaseFeatureCoveredForCategory,
-  increaseAcceptableSpecsForCategory
+  increaseAcceptableSpecsForCategory,
+  setCategories
 }

--- a/test/check-references.test.js
+++ b/test/check-references.test.js
@@ -6,7 +6,7 @@ test('check-references: Happy path, 100% referenced', t => {
   t.plan(4)
 
   quiet()
-  const { exitCode, res } = checkReferences('./test/check-references/complete-coverage/**/*.md', './test/check-references/complete-coverage/**/*.{feature,py}')
+  const { exitCode, res } = checkReferences('./test/check-references/complete-coverage/**/*.md', './test/check-references/complete-coverage/**/*.{feature,py}', './test/test-data/categories.json')
   loud()
 
   t.equal(exitCode, 0, 'Success')
@@ -19,7 +19,7 @@ test('check-references: 50% referenced, both from one spec', t => {
   t.plan(5)
 
   quiet()
-  const { exitCode, res } = checkReferences('./test/check-references/fifty-percent/**/*.md', './test/check-references/fifty-percent/**/*.{feature,py}')
+  const { exitCode, res } = checkReferences('./test/check-references/fifty-percent/**/*.md', './test/check-references/fifty-percent/**/*.{feature,py}', './test/test-data/categories.json')
   loud()
 
   t.equal(exitCode, 0, 'Success')
@@ -33,7 +33,7 @@ test('check-references: multiple specs, multiple tests', t => {
   t.plan(5)
 
   quiet()
-  const { exitCode, res } = checkReferences('./test/check-references/complex/specs/*.{md,ipynb}', './test/check-references/complex/**/*.{feature,py}')
+  const { exitCode, res } = checkReferences('./test/check-references/complex/specs/*.{md,ipynb}', './test/check-references/complex/**/*.{feature,py}', './test/test-data/categories.json')
   loud()
 
   t.equal(exitCode, 0, 'Success')
@@ -47,7 +47,7 @@ test('check-references: README is ignored', t => {
   t.plan(4)
 
   quiet()
-  const { exitCode, res } = checkReferences('./test/check-references/readme-is-ignored/**/*.md', './test/check-references/readme-is-ignored/**/*.{feature,py}')
+  const { exitCode, res } = checkReferences('./test/check-references/readme-is-ignored/**/*.md', './test/check-references/readme-is-ignored/**/*.{feature,py}', './test/test-data/categories.json')
   loud()
 
   t.equal(exitCode, 0, 'Success')
@@ -61,8 +61,8 @@ test('check-references: Ignore ignores specs...', t => {
   t.plan(4)
 
   quiet()
-  const allFiles = checkReferences(`${path}*.md`, `${path}*.{feature,py}`)
-  const ignore = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, `${path}0002*.md`)
+  const allFiles = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, './test/test-data/categories.json')
+  const ignore = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, './test/test-data/categories.json', `${path}0002*.md`)
   loud()
 
   t.equal(allFiles.res.criteriaTotal, 2, 'All files: two criteria exist')
@@ -77,8 +77,8 @@ test('check-references: ...ignore also applies to tests...', t => {
   t.plan(4)
 
   quiet()
-  const allFiles = checkReferences(`${path}*.md`, `${path}*.{feature,py}`)
-  const ignore = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, `${path}another-test.feature`)
+  const allFiles = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, './test/test-data/categories.json')
+  const ignore = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, './test/test-data/categories.json', `${path}another-test.feature`)
   loud()
 
   t.equal(allFiles.res.criteriaTotal, 2, 'All files: two criteria exist')
@@ -93,8 +93,8 @@ test('check-references: ...which is to say both simultaneously', t => {
   t.plan(4)
 
   quiet()
-  const allFiles = checkReferences(`${path}*.md`, `${path}*.{feature,py}`)
-  const ignore = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, `${path}{another-test*,0001*}`)
+  const allFiles = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, './test/test-data/categories.json')
+  const ignore = checkReferences(`${path}*.md`, `${path}*.{feature,py}`, './test/test-data/categories.json', `${path}{another-test*,0001*}`)
   loud()
 
   t.equal(allFiles.res.criteriaTotal, 2, 'All files: two criteria exist')
@@ -109,7 +109,7 @@ test('check-references: detect references in tests that are not in specs', t => 
   t.plan(4)
 
   quiet()
-  const { res } = checkReferences(`${path}*.md`, `${path}*.feature`)
+  const { res } = checkReferences(`${path}*.md`, `${path}*.feature`, './test/test-data/categories.json')
   loud()
 
   t.equal(res.criteriaTotal, 2, 'Two valid criteria exist in specs')

--- a/test/test-data/categories.json
+++ b/test/test-data/categories.json
@@ -1,0 +1,44 @@
+{
+  "Fundamentals": {
+    "specs": ["0017-PART", "0022-AUTH", "0051-PROD", "0016-PFUT", "0053-PERP", "0040-ASSF", "0013-ACCT", "0028-GOVE", "0054-NETP", "0068-MATC", "0067-KEYS", "0057-TRAN", "0052-FPOS"]
+  },
+  "Markets": {
+    "specs": ["0035-LIQM", "0032-PRIM", "0043-MKTL", "0026-AUCT", "0006-POSI", "0008-TRAD", "0001-MKTF", "0009-MRKP", "0012-POSR", "0021-MDAT", "0039-MKTD", "0070-MKTD"]
+  },
+  "Settlement & Oracles": {
+    "specs": ["0002-STTL", "0003-MTMK", "0045-DSRC", "0046-DSRM", "0047-DSRF", "0048-DSRI"]
+  },
+  "Protections": {
+    "specs": ["0073-LIMN", "0072-SPPW", "0062-SPAM", "0060-WEND", "0003-NP-LIMI", "0072-SPPW"]
+  },
+  "Liquidity": {
+    "specs": ["0044-LIME", "0042-LIQF", "0034-PROB"]
+  },
+  "Governance": {
+    "specs": ["0028-GOVE", "0027-ASSP", "0059-STKG", "0058-REWS", "0056-REWA", "0055-TREA"]
+  },
+  "Orders": {
+    "specs": ["0014-ORDT", "0004-AMND", "0024-OSTA", "0025-OCRE", "0037-OPEG", "0033-OCAN", "0038-OLIQ", "0074-BTCH"]
+  },
+  "Margin": {
+    "specs": ["0029-FEES", "0005-COLL", "0010-MARG", "0011-MARA", "0015-INSR", "0019-MCAL", "0018-RSKM", "0023-CALI"]
+  },
+  "Bridges": {
+    "specs": ["0049-TVAL", "0050-EPOC", "0030-ETHM", "0031-ETHB"]
+  },
+  "Staking & Validators": {
+    "specs": ["0071-STAK", "0059-STKG", "0056-REWA", "0061-REWP", "0058-REWS", "0055-TREA", "0041-TSTK", "0069-VCBS", "0066-VALW", "0065-FTCO", "0064-VALP", "0063-VALK"]
+  },
+  "Architecture": {
+    "specs": ["0036-BRIE", "0077-SNAP", "0075-PLUP"]
+  },
+  "Data": {
+    "specs": ["0076-DANO", "0020-APIS", "0007-POSN"]
+  },
+  "UI": {
+    "specs": ["1000-ASSO", "1001-VEST", "1002-STAK", "1003-INCO", "1004-VOTE", "1005-PROP", "1006-NETW", "1007-WALL", "3000-DEPO", "3001-WITH", "5000-MARK", "6000-COLL", "6001-SORD", "6002-MORD", "6003-POSI", "6004-FILL"]
+  },
+  "Unknown": {
+    "specs": []
+  }
+}


### PR DESCRIPTION
Building support for approbation runs with different categories to
support the new User Interface acceptance criteria

- Add `categories` param to point approbation at a JSON file of categories
- Remove built in categories
- Remove built in defaults for `specs` and `tests`

# Not done (hence draft)
- [x] Listing which *app* covers which criteria. Must not interfere with Core run.
 
Closes #48
