### PR TITLE
chore: update priorities for cosmicelevator specs

### DIFF
--- a/src/lib/priority.js
+++ b/src/lib/priority.js
@@ -34,6 +34,7 @@ const specPriorities = {
   '0011-NP-CLIE': 2,
   '0063-VALK': 2,
   '0012-NP-LIPE': 2,
+  '0080-SPOT': 2,
   // ==============
   '0017-PART': 3,
   '0025-OCRE': 3,

--- a/src/lib/priority.js
+++ b/src/lib/priority.js
@@ -33,6 +33,7 @@ const specPriorities = {
   '0079-TGAP': 2,
   '0011-NP-CLIE': 2,
   '0063-VALK': 2,
+  '0012-NP-LIPE': 2,
   // ==============
   '0017-PART': 3,
   '0025-OCRE': 3,


### PR DESCRIPTION
In order for the approbation pipeline to pick up the latest specs this adds them to the priority listing for the report.

Priorities are to be reviewed.