### PR TITLE
Add support for features file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,22 @@ docker run -v "$(pwd):/run" ghcr.io/vegaprotocol/approbation:latest check-filena
 > Coverage statistics for acceptance criteria
     
 **Arguments**
-| **Parameter**   | **Type** | **Description**                      | **Example**          |
-|-----------------|----------|--------------------------------------|----------------------|
-| `--tests`         | glob     | tests to check for AC codes          | `tests/**/*.{py,feature}`    |
-| `--specs`         | glob     | specs to pull AC codes from          | `{specs/**/*.md}`    |
-| `--ignore`        | glob     | glob of files not to check for codes | `specs/0001-spec.md` |
-| `--categories`  | string  | JSON file that contains category mappings for specs          | `specs/categories.json`    |
-| `--show-branches` | boolean  | Show git branches for subfolders of the current folder | -  | 
-| `--show-mystery`  | boolean  | display criteria in tests that are not in any specs matched by `--specs`          | -    |
-| `--show-files`  | boolean  | display basic stats per file         | -    |
-| `--show-file-stats`  | boolean  | display detailed stats per file         | -    |
-| `--output-csv`  | boolean  | Outputs a CSV file to summarise the console output          | -    |
-| `--output-jenkins`  | boolean  | Outputs a text file to summarise the console output, to sendover to jenkins          | -    |
-| `--output`  | string  | A path to write the CSV or Jenkins output to | `./results`    |
-| `--verbose`  | boolean  | MORE output        | -    |
+| **Parameter**       | **Type** | **Description**                                                             | **Example**               |
+| ------------------- | -------- | --------------------------------------------------------------------------- | ------------------------- |
+| `--tests`           | glob     | tests to check for AC codes                                                 | `tests/**/*.{py,feature}` |
+| `--specs`           | glob     | specs to pull AC codes from                                                 | `{specs/**/*.md}`         |
+| `--ignore`          | glob     | glob of files not to check for codes                                        | `specs/0001-spec.md`      |
+| `--categories`      | string   | JSON file that contains category mappings for specs                         | `specs/categories.json`   |
+| `--features`        | string   | JSON file that contains features mappings for specs                         | `specs/features.json`     |
+| `--show-branches`   | boolean  | Show git branches for subfolders of the current folder                      | -                         |
+| `--show-mystery`    | boolean  | display criteria in tests that are not in any specs matched by `--specs`    | -                         |
+| `--show-files`      | boolean  | display basic stats per file                                                | -                         |
+| `--show-file-stats` | boolean  | display detailed stats per file                                             | -                         |
+| `--output-csv`      | boolean  | Outputs a CSV file to summarise the console output                          | -                         |
+| `--output-jenkins`  | boolean  | Outputs a text file to summarise the console output, to sendover to jenkins | -                         |
+| `--output`          | string   | A path to write the CSV or Jenkins output to                                | `./results`               |
+| `--verbose`         | boolean  | MORE output                                                                 | -                         |
+
 
 ### check-references example
 ```bash

--- a/bin/approbation.js
+++ b/bin/approbation.js
@@ -99,6 +99,7 @@ if (command === 'check-filenames') {
   const specsGlob = argv.specs
   const testsGlob = argv.tests
   const categories = argv.categories
+  const features = argv.features
   const ignoreGlob = argv.ignore
   const showMystery = argv['show-mystery'] === true
   const showCategoryStats = argv['category-stats'] === true
@@ -139,7 +140,7 @@ if (command === 'check-filenames') {
   }
 
   // TODO: Turn in to an object
-  res = checkReferences(specsGlob, testsGlob, categories, ignoreGlob, showMystery, isVerbose, showCategoryStats, showFiles, shouldOutputCSV, shouldOutputJenkins, shouldShowFileStats, outputPath)
+  res = checkReferences(specsGlob, testsGlob, categories, ignoreGlob, features, showMystery, isVerbose, showCategoryStats, showFiles, shouldOutputCSV, shouldOutputJenkins, shouldShowFileStats, outputPath)
 
   process.exit(res.exitCode)
 } else {
@@ -177,6 +178,7 @@ if (command === 'check-filenames') {
   showArg(`--specs="${pc.yellow('{specs/**/*.md}')}"`, 'glob of specs to pull AC codes from ')
   showArg(`--tests="${pc.yellow('tests/**/*.{py,feature}')}"`, 'glob of tests to match to the spec AC codes')
   showArg(`--categories="${pc.yellow('./specs/protocol/categories.json')}"`, 'Single JSON file that contains the categories for this test run')
+  showArg(`--features="${pc.yellow('./specs/protocol/features.json')}"`, 'Single JSON file that contains the features for this test run')
   showArg(`--ignore="${pc.yellow('{tests/**/*.{py,feature}')}"`, 'glob of files to ignore for both tests and specs')
   showArg('--show-mystery', 'If set, display criteria in tests that are not in any specs matched by --specs')
   showArg('--category-stats', 'Show more detail for referenced/unreferenced codes')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "4.4.1",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vegaprotocol/approbation",
-      "version": "4.4.1",
+      "version": "4.6.0",
       "license": "Unlicense",
       "dependencies": {
         "console-table-printer": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Match Acceptance Criteria Codes with the tests that test them",
   "engine": ">= 18",
   "bin": "./bin/approbation.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "4.6.0",
+  "version": "4.5.0",
   "description": "Match Acceptance Criteria Codes with the tests that test them",
   "engine": ">= 18",
   "bin": "./bin/approbation.js",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@vegaprotocol/approbation",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "description": "Match Acceptance Criteria Codes with the tests that test them",
   "engine": ">= 18",
   "bin": "./bin/approbation.js",
   "scripts": {
-    "test:ci": "tape test/*.js",
-    "test": "tape test/*.js | tap-arc"
+    "test:ci": "tape 'test/**/*.test.js'",
+    "test": "tape 'test/**/*.test.js' | tap-arc"
   },
   "repository": {
     "type": "git",

--- a/src/check-references.js
+++ b/src/check-references.js
@@ -220,7 +220,10 @@ function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, feat
       specCategories = JSON.parse(fs.readFileSync(categoriesPath))
       setCategories(specCategories)
       // Features gather Acceptance Criteria across spec files or categories, and tally the numbers
-      specFeatures = setFeatures(JSON.parse(fs.readFileSync(featuresPath)))
+      
+      if (featuresPath !== undefined) {
+        specFeatures = setFeatures(JSON.parse(fs.readFileSync(featuresPath)))
+      }
 
       specs = gatherSpecs(specList)
       tests = gatherTests(testList)
@@ -279,7 +282,7 @@ function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, feat
       console.log(st.render())
     }
     
-    if (true) {
+    if (featuresPath) {
       const totals = []
       const milestoneNames = new Set()
       const milestones = new Map()
@@ -296,7 +299,6 @@ function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, feat
             Array.from(c.uncoveredAcs).join(', ')
           )
         }
-          
 
         milestones.get(c.milestone).push({
           Feature: key,

--- a/src/check-references.js
+++ b/src/check-references.js
@@ -11,6 +11,7 @@ const path = require('path')
 const pc = require('picocolors')
 const { validSpecificationPrefix, validAcceptanceCriteriaCode, ignoreFiles } = require('./lib')
 const { getCategoriesForSpec, increaseCodesForCategory, increaseCoveredForCategory, increaseAcceptableSpecsForCategory, increaseUncoveredForCategory, increaseFeatureCoveredForCategory, increaseSystemTestCoveredForCategory, increaseSpecCountForCategory, setCategories } = require('./lib/category')
+const { setFeatures, increaseAcceptableSpecsForFeature, increaseCodesForFeature, increaseCoveredForFeature, increaseFeatureCoveredForFeature, increaseSpecCountForFeature, increaseSystemTestCoveredForFeature, increaseUncoveredForFeature } = require('./lib/feature')
 const { Table } = require('console-table-printer')
 const { specPriorities } = require('./lib/priority')
 const sortBy = require('lodash.sortby')
@@ -124,16 +125,19 @@ function processReferences (specs, tests) {
           criteriaWithRefs.push(c)
           criteriaReferencedTotal++
           categories.forEach(c => increaseCoveredForCategory(c, 1))
+          increaseCoveredForFeature(c, 1)
 
           // Hacky hack: Limit these to 1 or 0 rather than a true tally.
           let criteriaAlreadyLoggedSystest = false
           let criteriaAlreadyLoggedFeature = false
           linksForAC.forEach(l => {
             if (!criteriaAlreadyLoggedSystest && l.match('system-tests')) {
+              increaseSystemTestCoveredForFeature(c, 1)
               categories.forEach(c => increaseSystemTestCoveredForCategory(c, 1))
               value.referencedBySystemTest++
               criteriaAlreadyLoggedSystest = true
             } else if (!criteriaAlreadyLoggedFeature && l.match('.feature')) {
+              increaseFeatureCoveredForFeature(c, 1)
               categories.forEach(c => increaseFeatureCoveredForCategory(c, 1))
               value.referencedByFeature++
               criteriaAlreadyLoggedFeature = true
@@ -150,6 +154,7 @@ function processReferences (specs, tests) {
       if (criteriaWithRefs.length !== value.criteria.length) {
         value.criteria.forEach(v => {
           if (!criteriaWithRefs.includes(v)) {
+            increaseUncoveredForFeature(v, 1)
             unreferencedCriteria.push(v)
             criteriaUnreferencedTotal++
           }
@@ -197,7 +202,7 @@ function processReferences (specs, tests) {
   }
 }
 
-function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, showMystery = false, isVerbose = false, showCategoryStats = false, shouldShowFiles = false, shouldOutputCSV = false, shouldOutputJenkins = false, shouldShowFileStats = false, outputPath = './results') {
+function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, featuresPath, showMystery = false, isVerbose = false, showCategoryStats = false, shouldShowFiles = false, shouldOutputCSV = false, shouldOutputJenkins = false, shouldShowFileStats = false, outputPath = './results') {
   verbose = isVerbose
   showFiles = shouldShowFiles
 
@@ -206,13 +211,18 @@ function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, show
   const testList = ignoreFiles(glob.sync(testsGlob, {}), ignoreList, 'test')
   let categories
 
-  let specs, tests, specCategories
+  let specs, tests, features, specFeatures
   const exitCode = 0
+
 
   if (specList.length > 0 && testList.length > 0) {
     try {
+      // Categories gather spec files in to categories, and tally the number of codes in each category
       specCategories = JSON.parse(fs.readFileSync(categoriesPath))
       setCategories(specCategories)
+      // Features gather Acceptance Criteria across spec files or categories, and tally the numbers
+      specFeatures = setFeatures(JSON.parse(fs.readFileSync(featuresPath)))
+
       specs = gatherSpecs(specList)
       tests = gatherTests(testList)
     } catch (e) {
@@ -269,6 +279,52 @@ function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, show
       st.addRows(sortBy(specsTableRows, ['Priority', 'Coverage']))
       console.log(st.render())
     }
+    
+    if (true) {
+      const milestoneNames = new Set()
+      const milestones = new Map()
+      Object.keys(specFeatures).forEach(key => milestoneNames.add(specFeatures[key].milestone))
+      milestoneNames.forEach(m => milestones.set(m, []))
+      
+      Object.keys(specFeatures).filter(k => k !== 'Unknown').forEach(key => {
+        const c = specFeatures[key]
+        const coverage = (c.covered / (c.acs.length | 0) * 100).toFixed(1)
+
+        milestones.get(c.milestone).push({
+          Feature: key,
+          Milestone: c.milestone || 0,
+          acs: c.acs.length || 0,
+          Covered: c.covered || 0,
+          'by/FeatTest': c.featureCovered || 0,
+          'by/SysTest': c.systemTestCovered || 0,
+          Uncovered: c.uncovered || 0,
+          Coverage: isNaN(coverage) ? '0%' : `${coverage}%`
+        })
+      })
+
+      milestones.forEach((featuresByMilestone, milestoneKey) => {
+        const Covered = featuresByMilestone.reduce((acc, cur) => acc + cur.Covered, 0);
+        const acs = featuresByMilestone.reduce((acc, cur) => acc + cur.acs, 0);
+        const Coverage = `${(Covered / acs * 100).toFixed(1)}%`
+        featuresByMilestone.push({
+          Feature: `** Total`,
+          Milestone: milestoneKey || '-',
+          acs,
+          Covered,
+          'by/FeatTest': featuresByMilestone.reduce((acc, cur) => acc + cur['by/FeatTest'], 0) || '-',
+          'by/SysTest': featuresByMilestone.reduce((acc, cur) => acc + cur['by/SysTest'], 0) || '-',
+          Uncovered: featuresByMilestone.reduce((acc, cur) => acc + cur.Uncovered, 0) || '-',
+          Coverage
+        })
+      })
+
+      const t = new Table()
+      t.addRows(milestones.get('deployment-1'));
+      t.addRows(milestones.get('deployment-2'));
+      const tableOutput = t.render()
+      console.log(tableOutput)
+    }
+
     if (showCategoryStats) {
       const shouldOutputImage = false
 

--- a/src/check-references.js
+++ b/src/check-references.js
@@ -11,7 +11,7 @@ const path = require('path')
 const pc = require('picocolors')
 const { validSpecificationPrefix, validAcceptanceCriteriaCode, ignoreFiles } = require('./lib')
 const { getCategoriesForSpec, increaseCodesForCategory, increaseCoveredForCategory, increaseAcceptableSpecsForCategory, increaseUncoveredForCategory, increaseFeatureCoveredForCategory, increaseSystemTestCoveredForCategory, increaseSpecCountForCategory, setCategories } = require('./lib/category')
-const { setFeatures, increaseAcceptableSpecsForFeature, increaseCodesForFeature, increaseCoveredForFeature, increaseFeatureCoveredForFeature, increaseSpecCountForFeature, increaseSystemTestCoveredForFeature, increaseUncoveredForFeature } = require('./lib/feature')
+const { setFeatures, increaseAcceptableSpecsForFeature, increaseCodesForFeature, increaseCoveredForFeature, increaseFeatureCoveredForFeature, increaseSpecCountForFeature, increaseSystemTestCoveredForFeature, increaseUncoveredForFeature, specFeatures } = require('./lib/feature')
 const { Table } = require('console-table-printer')
 const { specPriorities } = require('./lib/priority')
 const sortBy = require('lodash.sortby')
@@ -289,6 +289,12 @@ function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, feat
       Object.keys(specFeatures).filter(k => k !== 'Unknown').forEach(key => {
         const c = specFeatures[key]
         const coverage = (c.covered / (c.acs.length | 0) * 100).toFixed(1)
+        
+        if (c.uncovered !== 0 && c.uncoveredAcs) {
+          console.group(pc.red(`Uncovered ACs for ${key}`))
+          console.dir(Array.from(c.uncoveredAcs).join(', '))
+          console.groupEnd()
+        }
 
         milestones.get(c.milestone).push({
           Feature: key,
@@ -300,6 +306,7 @@ function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, feat
           Uncovered: c.uncovered || 0,
           Coverage: isNaN(coverage) ? '0%' : `${coverage}%`
         })
+
       })
 
       milestones.forEach((featuresByMilestone, milestoneKey) => {

--- a/src/check-references.js
+++ b/src/check-references.js
@@ -291,10 +291,12 @@ function checkReferences (specsGlob, testsGlob, categoriesPath, ignoreGlob, feat
         const coverage = (c.covered / (c.acs.length | 0) * 100).toFixed(1)
         
         if (c.uncovered !== 0 && c.uncoveredAcs) {
-          console.group(pc.red(`Uncovered ACs for ${key}`))
-          console.dir(Array.from(c.uncoveredAcs).join(', '))
-          console.groupEnd()
+          console.log(
+            pc.red(`Uncovered ACs for ${key} (${c.milestone}): `) + 
+            Array.from(c.uncoveredAcs).join(', ')
+          )
         }
+          
 
         milestones.get(c.milestone).push({
           Feature: key,

--- a/src/lib/feature.js
+++ b/src/lib/feature.js
@@ -80,6 +80,20 @@ function setOrIncreaseProperty(feature, property, value) {
   }
 }
 
+function logUncoveredForFeature(feature) {
+  let f = (feature.match(validAcceptanceCriteriaCode) ? getFeatureForAc(feature) : feature);
+
+  if (isFeatureEmpty() || !specFeatures[f]) {
+    f = 'Unknown';
+  }
+
+  if (specFeatures[f]['uncoveredAcs']) {
+    specFeatures[f]['uncoveredAcs'].add(feature);
+  } else {
+    specFeatures[f]['uncoveredAcs'] = new Set([feature]);
+  } 
+}
+
 function increaseCodesForFeature(feature, count) {
   if (isFeatureEmpty()) {
     throw ErrorFeatureEmpty;
@@ -113,6 +127,7 @@ function increaseUncoveredForFeature(feature, count) {
     throw ErrorFeatureEmpty;
   }
   setOrIncreaseProperty(feature, "uncovered", count);
+  logUncoveredForFeature(feature);
 }
 
 function increaseSpecCountForFeature(feature) {

--- a/src/lib/feature.js
+++ b/src/lib/feature.js
@@ -7,13 +7,12 @@
 
 const { validAcceptanceCriteriaCode } = require(".");
 
-const ErrorFeaturesEmpty = new Error("Features have not been set");
 let specFeatures;
 let acToFeatureLookup = new Map()
 
 function isFeatureEmpty() {
   if (specFeatures === undefined) {
-    throw ErrorFeaturesEmpty;
+    return true
   }
   return Object.keys(specFeatures).length === 0;
 }
@@ -30,7 +29,7 @@ function isFeatureEmpty() {
 function isValidFeature(featureName, feature) {
   // Has a name set
   if (!featureName || !featureName.length) {
-    return false;
+    return false
   }
 
   // Feature must have acceptance criteria and more than 0
@@ -96,35 +95,35 @@ function logUncoveredForFeature(feature) {
 
 function increaseCodesForFeature(feature, count) {
   if (isFeatureEmpty()) {
-    throw ErrorFeatureEmpty;
+    return false
   }
   setOrIncreaseProperty(feature, "codes", count);
 }
 
 function increaseCoveredForFeature(feature, count) {
   if (isFeatureEmpty()) {
-    throw ErrorFeatureEmpty;
+    return false
   }
   setOrIncreaseProperty(feature, "covered", count);
 }
 
 function increaseFeatureCoveredForFeature(feature, count) {
   if (isFeatureEmpty()) {
-    throw ErrorFeatureEmpty;
+    return false
   }
   setOrIncreaseProperty(feature, "featureCovered", count);
 }
 
 function increaseSystemTestCoveredForFeature(feature, count) {
   if (isFeatureEmpty()) {
-    throw ErrorFeatureEmpty;
+    return false
   }
   setOrIncreaseProperty(feature, "systemTestCovered", count);
 }
 
 function increaseUncoveredForFeature(feature, count) {
   if (isFeatureEmpty()) {
-    throw ErrorFeatureEmpty;
+    return false
   }
   setOrIncreaseProperty(feature, "uncovered", count);
   logUncoveredForFeature(feature);
@@ -132,14 +131,14 @@ function increaseUncoveredForFeature(feature, count) {
 
 function increaseSpecCountForFeature(feature) {
   if (isFeatureEmpty()) {
-    throw ErrorFeatureEmpty;
+    return false
   }
   setOrIncreaseProperty(feature, "specCount", 1);
 }
 
 function increaseAcceptableSpecsForFeature(feature) {
   if (isFeatureEmpty()) {
-    throw ErrorFeatureEmpty;
+    return false
   }
   setOrIncreaseProperty(feature, "acceptableSpecCount", 1);
 }

--- a/src/lib/feature.js
+++ b/src/lib/feature.js
@@ -1,0 +1,143 @@
+/* Features are a lot like categories, except they map together specific
+ * acceptance criteria across files in to a single unified feature.
+ *
+ * As I write this, it feels like it's working against some of the logic
+ * that is used to generate codes - so this may lead to an approbation v2.
+ */
+
+const { validAcceptanceCriteriaCode } = require(".");
+
+const ErrorFeaturesEmpty = new Error("Features have not been set");
+let specFeatures;
+let acToFeatureLookup = new Map()
+
+function isFeatureEmpty() {
+  if (specFeatures === undefined) {
+    throw ErrorFeaturesEmpty;
+  }
+  return Object.keys(specFeatures).length === 0;
+}
+
+/**
+ * Validates a Feature object, presumably read from a features.json type
+ * file. Features should have a milestone, and a list of criteria that are
+ * in the feature. There is no clever wildcard matching, it's all manual.
+ *
+ * @param {string} featureName the key of the feature in the features.json file
+ * @param {Object} feature an object containing the feature config
+ * @returns boolean True if it is valid
+ */
+function isValidFeature(featureName, feature) {
+  // Has a name set
+  if (!featureName || !featureName.length) {
+    return false;
+  }
+
+  // Feature must have acceptance criteria and more than 0
+  if (!feature.acs || !feature.acs.length) {
+    return false;
+  }
+
+  // Feature must have a milestone
+  if (!feature.milestone || !feature.milestone.length) {
+    return false;
+  }
+
+  return true;
+}
+
+function setFeatures(fileFeatures) {
+  specFeatures = fileFeatures;
+  if (!specFeatures.Unknown) {
+    specFeatures.Unknown = { acs: [], milestone: "-", acCount: 0 };
+  }
+  
+  Object.entries(specFeatures).forEach(([featureName, feature]) => {
+    feature.acs.forEach((ac) => {
+      acToFeatureLookup.set(ac, featureName);
+    })
+  })
+
+  return specFeatures;
+}
+
+function getFeatureForAc(ac) {
+  const f = acToFeatureLookup.get(ac);
+  return f
+}
+
+function setOrIncreaseProperty(feature, property, value) {
+  let f = (feature.match(validAcceptanceCriteriaCode) ? getFeatureForAc(feature) : feature);
+
+  if (isFeatureEmpty() || !specFeatures[f]) {
+    f = 'Unknown';
+  }
+
+  if (specFeatures[f][property]) {
+    specFeatures[f][property] += value;
+  } else {
+    specFeatures[f][property] = value;
+  }
+}
+
+function increaseCodesForFeature(feature, count) {
+  if (isFeatureEmpty()) {
+    throw ErrorFeatureEmpty;
+  }
+  setOrIncreaseProperty(feature, "codes", count);
+}
+
+function increaseCoveredForFeature(feature, count) {
+  if (isFeatureEmpty()) {
+    throw ErrorFeatureEmpty;
+  }
+  setOrIncreaseProperty(feature, "covered", count);
+}
+
+function increaseFeatureCoveredForFeature(feature, count) {
+  if (isFeatureEmpty()) {
+    throw ErrorFeatureEmpty;
+  }
+  setOrIncreaseProperty(feature, "featureCovered", count);
+}
+
+function increaseSystemTestCoveredForFeature(feature, count) {
+  if (isFeatureEmpty()) {
+    throw ErrorFeatureEmpty;
+  }
+  setOrIncreaseProperty(feature, "systemTestCovered", count);
+}
+
+function increaseUncoveredForFeature(feature, count) {
+  if (isFeatureEmpty()) {
+    throw ErrorFeatureEmpty;
+  }
+  setOrIncreaseProperty(feature, "uncovered", count);
+}
+
+function increaseSpecCountForFeature(feature) {
+  if (isFeatureEmpty()) {
+    throw ErrorFeatureEmpty;
+  }
+  setOrIncreaseProperty(feature, "specCount", 1);
+}
+
+function increaseAcceptableSpecsForFeature(feature) {
+  if (isFeatureEmpty()) {
+    throw ErrorFeatureEmpty;
+  }
+  setOrIncreaseProperty(feature, "acceptableSpecCount", 1);
+}
+
+module.exports = {
+  isValidFeature,
+  setFeatures,
+  specFeatures,
+  increaseAcceptableSpecsForFeature,
+  increaseCodesForFeature,
+  increaseCoveredForFeature,
+  increaseFeatureCoveredForFeature,
+  increaseSpecCountForFeature,
+  increaseSystemTestCoveredForFeature,
+  increaseUncoveredForFeature,
+};

--- a/test/check-references.test.js
+++ b/test/check-references.test.js
@@ -126,7 +126,7 @@ test('check-references: Specs can be in multiple categories at once', t => {
   t.plan(20)
 
   quiet()
-  const { res } = checkReferences(`${path}*.md`, `${path}*.feature`, './test/check-references/multiple-categories/categories/categories.json', '', '', false, false, true)
+  const { res } = checkReferences(`${path}*.md`, `${path}*.feature`, './test/check-references/multiple-categories/categories/categories.json', '', undefined, false, false, true, true)
   loud()
 
   const c = res.categories

--- a/test/check-references.test.js
+++ b/test/check-references.test.js
@@ -126,7 +126,7 @@ test('check-references: Specs can be in multiple categories at once', t => {
   t.plan(20)
 
   quiet()
-  const { res } = checkReferences(`${path}*.md`, `${path}*.feature`, './test/check-references/multiple-categories/categories/categories.json', '', false, false, true)
+  const { res } = checkReferences(`${path}*.md`, `${path}*.feature`, './test/check-references/multiple-categories/categories/categories.json', '', '', false, false, true)
   loud()
 
   const c = res.categories

--- a/test/lib/feature.test.js
+++ b/test/lib/feature.test.js
@@ -1,0 +1,47 @@
+const { isValidFeature } = require('../../src/lib/feature');
+const test = require('tape');
+
+test('isValidFeature: Valid feature', (t) => {
+    const feature1 = {
+        acs: ["Some acceptance criteria"],
+        milestone: "Some milestone"
+    };
+    t.equal(isValidFeature("Feature 1", feature1), true);
+    t.end();
+});
+
+test('isValidFeature: Invalid feature name', (t) => {
+    const feature2 = {
+        acs: ["Some acceptance criteria"],
+        milestone: "Some milestone"
+    };
+    t.equal(isValidFeature("", feature2), false);
+    t.end();
+});
+
+test('isValidFeature: No acceptance criteria', (t) => {
+    const feature3 = {
+        acs: [],
+        milestone: "Some milestone"
+    };
+    t.equal(isValidFeature("Feature 3", feature3), false);
+    t.end();
+});
+
+test('isValidFeature: No milestone', (t) => {
+    const feature4 = {
+        acs: ["Some acceptance criteria"],
+        milestone: ""
+    };
+    t.equal(isValidFeature("Feature 4", feature4), false);
+    t.end();
+});
+
+test('isValidFeature: Invalid feature name and no milestone', (t) => {
+    const feature5 = {
+        acs: ["Some acceptance criteria"],
+        milestone: ""
+    };
+    t.equal(isValidFeature("", feature5), false);
+    t.end();
+});

--- a/test/next-code.test.js
+++ b/test/next-code.test.js
@@ -47,7 +47,9 @@ test("next-code: extractPrefixFromCodes: returns all unique prefixes found", (t)
 
 test("next-code: nextCode: returns the next code in the sequence", (t) => {
   t.plan(3);
+  quiet();
   const { exitCode, nextLowest, nextHighest } = nextCode('./test/next-code/big-skip/*.md','', false)
+  loud();
 
   t.equal(exitCode, 0, "Exit code is 0");
   t.equal(nextLowest, "002", "Next lowest is 003");


### PR DESCRIPTION
- feat(approbation): add support for features file

See specs repo PRs for a new features file. Combined with this messy PR, it gives coverage output for a feature level.

# Overview
This new parameter allows Acceptance Criteria to be grouped by Feature, in a similar way to Categories. Features are being used in the [upcoming Cosmic Elevator milestone](https://github.com/orgs/vegaprotocol/projects/132) to track the development of new core functionality

## Usage
`check-references` now supports a `featuers` parameter: `--features="specs/protocol/features.json"`. This will make it output a new table that looks a bit like this:

```
┌────────────────────────┬──────────────┬─────┬─────────┬─────────────┬────────────┬───────────┬──────────┐
│                Feature │    Milestone │ acs │ Covered │ by/FeatTest │ by/SysTest │ Uncovered │ Coverage │
├────────────────────────┼──────────────┼─────┼─────────┼─────────────┼────────────┼───────────┼──────────┤
│   Governance Transfers │ deployment-1 │  46 │      41 │           0 │         41 │         5 │    89.1% │
│         Iceberg Orders │ deployment-1 │  34 │      33 │          22 │         12 │         1 │    97.1% │
│            Stop Orders │ deployment-1 │  39 │      37 │          30 │          7 │         2 │    94.9% │
│      Successor Markets │ deployment-1 │  40 │      28 │          13 │         17 │        10 │    70.0% │
│                  Perps │ deployment-2 │  13 │       0 │           0 │          0 │        13 │       0% │
│                   Spot │ deployment-2 │ 348 │       4 │           1 │          4 │       315 │     1.1% │
│       Ethereum Oracles │ deployment-2 │  45 │       1 │           0 │          1 │        41 │     2.2% │
│                    SLA │ deployment-2 │  72 │      17 │           0 │          6 │        53 │    23.6% │
│ Batch change proposals │ deployment-2 │   5 │       0 │           0 │          0 │         5 │       0% │
│       Referral program │ deployment-2 │   2 │       0 │           0 │          0 │         0 │       0% │
│      Market governance │ deployment-2 │  15 │       0 │           0 │          0 │        15 │       0% │
│                    --- │          --- │ --- │     --- │         --- │        --- │       --- │      --- │
│                  Total │ deployment-1 │ 159 │     139 │          65 │         77 │        18 │    87.4% │
│                  Total │ deployment-2 │ 500 │      22 │           1 │         11 │       442 │     4.4% │
└────────────────────────┴──────────────┴─────┴─────────┴─────────────┴────────────┴───────────┴──────────┘
```

Additionally it outputs which ACs are uncovered per feature, above the table:
```
Uncovered ACs for Governance Transfers (deployment-1): 0028-GOVE-140, 0028-GOVE-141, 0028-GOVE-144, 0028-GOVE-142, 0028-GOVE-143
Uncovered ACs for Iceberg Orders (deployment-1): 0014-ORDT-069
Uncovered ACs for Stop Orders (deployment-1): 0079-TGAP-004, 0079-TGAP-005
Uncovered ACs for Successor Markets (deployment-1): 0001-MKTF-006, 0001-MKTF-007, 0001-MKTF-008, 0028-GOVE-093, 0081-SUCM-003, 0081-SUCM-030, 0081-SUCM-031, 0081-SUCM-032, 0081-SUCM-025, 0081-SUCM-026
Uncovered ACs for Perps (deployment-2): 0001-MKTF-005, 0053-PERP-001, 0053-PERP-002, 0053-PERP-003, 0053-PERP-004, 0053-PERP-005, 0053-PERP-006, 0053-PERP-007, 0053-PERP-008, 0053-PERP-009, 0053-PERP-015, 0053-PERP-016, 0053-PERP-017
Uncovered ACs for Spot (deployment-2): 0004-AMND-030, 0004-AMND-031, 0004-AMND-032, 0004-AMND-055, 0004-AMND-033, 0004-AMND-034, 0004-AMND-035, 0004-AMND-036, 0004-AMND-037, 0004-AMND-038, 0004-AMND-039, 0004-AMND-040, 0004-AMND-041, 0004-AMND-042, 0004-AMND-043, 0004-AMND-044, 0004-AMND-045, 0004-AMND-046, 0004-AMND-047, 0004-AMND-048, 0004-AMND-049, 0004-AMND-050, 0004-AMND-051, 0004-AMND-052, 0004-AMND-053, 0004-AMND-054, 0008-TRAD-008, 0011-MARA-018, 0011-MARA-019, 0011-MARA-020, 0011-MARA-021, 0011-MARA-022, 0011-MARA-023, 0011-MARA-024, 0011-MARA-025, 0011-MARA-026, 0011-MARA-027, 0011-MARA-028, 0011-MARA-029, 0011-MARA-030, 0011-MARA-031, 0011-MARA-032, 0013-ACCT-024, 0013-ACCT-025, 0013-ACCT-030, 0013-ACCT-031, 0014-ORDT-081, 0014-ORDT-082, 0014-ORDT-083, 0014-ORDT-084, 0014-ORDT-085, 0014-ORDT-086, 0014-ORDT-087, 0014-ORDT-088, 0014-ORDT-089, 0014-ORDT-090, 0014-ORDT-091, 0014-ORDT-092, 0014-ORDT-093, 0014-ORDT-094, 0014-ORDT-095, 0014-ORDT-096, 0014-ORDT-097, 0014-ORDT-098, 0014-ORDT-099, 0014-ORDT-100, 0014-ORDT-119, 0014-ORDT-101, 0014-ORDT-102, 0014-ORDT-103, 0014-ORDT-104, 0014-ORDT-105, 0014-ORDT-106, 0014-ORDT-107, 0014-ORDT-108, 0014-ORDT-109, 0014-ORDT-110, 0014-ORDT-111, 0014-ORDT-118, 0014-ORDT-112, 0014-ORDT-113, 0014-ORDT-114, 0014-ORDT-115, 0014-ORDT-116, 0014-ORDT-117, 0021-MDAT-013, 0021-MDAT-014, 0021-MDAT-015, 0021-MDAT-016, 0021-MDAT-017, 0021-MDAT-018, 0021-MDAT-019, 0021-MDAT-020, 0024-OSTA-030, 0024-OSTA-031, 0024-OSTA-032, 0024-OSTA-033, 0024-OSTA-034, 0024-OSTA-035, 0024-OSTA-036, 0024-OSTA-037, 0024-OSTA-038, 0024-OSTA-039, 0024-OSTA-040, 0024-OSTA-041, 0024-OSTA-042, 0024-OSTA-043, 0024-OSTA-044, 0024-OSTA-045, 0024-OSTA-046, 0024-OSTA-047, 0024-OSTA-048, 0025-OCRE-004, 0025-OCRE-005, 0025-OCRE-006, 0026-AUCT-023, 0026-AUCT-024, 0026-AUCT-025, 0026-AUCT-026, 0026-AUCT-027, 0026-AUCT-028, 0026-AUCT-029, 0026-AUCT-031, 0026-AUCT-032, 0029-FEES-015, 0029-FEES-016, 0029-FEES-017, 0029-FEES-018, 0029-FEES-019, 0029-FEES-020, 0029-FEES-021, 0029-FEES-022, 0032-PRIM-022, 0032-PRIM-023, 0032-PRIM-024, 0032-PRIM-025, 0032-PRIM-026, 0032-PRIM-027, 0032-PRIM-028, 0032-PRIM-029, 0032-PRIM-030, 0032-PRIM-031, 0032-PRIM-032, 0032-PRIM-033, 0032-PRIM-034, 0032-PRIM-035, 0032-PRIM-036, 0032-PRIM-037, 0032-PRIM-038, 0033-OCAN-011, 0033-OCAN-012, 0033-OCAN-013, 0033-OCAN-014, 0033-OCAN-015, 0033-OCAN-016, 0033-OCAN-017, 0034-PROB-007, 0034-PROB-008, 0034-PROB-009, 0037-OPEG-019, 0039-MKTD-020, 0039-MKTD-021, 0039-MKTD-022, 0039-MKTD-023, 0039-MKTD-024, 0039-MKTD-025, 0039-MKTD-026, 0039-MKTD-027, 0039-MKTD-028, 0039-MKTD-029, 0039-MKTD-030, 0039-MKTD-033, 0039-MKTD-031, 0039-MKTD-032, 0043-MKTL-005, 0043-MKTL-006, 0043-MKTL-007, 0043-MKTL-008, 0049-TVAL-007, 0049-TVAL-008, 0049-TVAL-009, 0049-TVAL-010, 0049-TVAL-011, 0049-TVAL-012, 0051-PROD-004, 0051-PROD-005, 0051-PROD-006, 0052-FPOS-003, 0052-FPOS-004, 0054-NETP-007, 0054-NETP-008, 0054-NETP-009, 0054-NETP-010, 0054-NETP-011, 0056-REWA-062, 0056-REWA-061, 0056-REWA-060, 0056-REWA-059, 0056-REWA-058, 0056-REWA-057, 0056-REWA-056, 0056-REWA-055, 0056-REWA-054, 0056-REWA-053, 0056-REWA-052, 0056-REWA-051, 0056-REWA-063, 0056-REWA-064, 0056-REWA-065, 0056-REWA-066, 0056-REWA-067, 0056-REWA-068, 0056-REWA-069, 0056-REWA-070, 0056-REWA-071, 0056-REWA-072, 0056-REWA-073, 0056-REWA-074, 0056-REWA-075, 0057-TRAN-063, 0065-FTCO-005, 0065-FTCO-006, 0065-FTCO-007, 0065-FTCO-008, 0068-MATC-061, 0068-MATC-062, 0068-MATC-063, 0068-MATC-064, 0068-MATC-065, 0068-MATC-066, 0068-MATC-067, 0068-MATC-068, 0068-MATC-069, 0068-MATC-070, 0068-MATC-071, 0068-MATC-072, 0068-MATC-073, 0068-MATC-074, 0068-MATC-075, 0068-MATC-076, 0068-MATC-077, 0068-MATC-078, 0068-MATC-079, 0068-MATC-080, 0068-MATC-081, 0068-MATC-082, 0068-MATC-083, 0068-MATC-084, 0068-MATC-085, 0068-MATC-086, 0068-MATC-087, 0068-MATC-088, 0068-MATC-060, 0068-MATC-089, 0068-MATC-090, 0068-MATC-092, 0068-MATC-091, 0070-MKTD-009, 0070-MKTD-010, 0070-MKTD-011, 0070-MKTD-012, 0070-MKTD-013, 0070-MKTD-014, 0070-MKTD-015, 0073-LIMN-101, 0073-LIMN-102, 0073-LIMN-103, 0073-LIMN-104, 0073-LIMN-077, 0073-LIMN-078, 0073-LIMN-079, 0073-LIMN-080, 0073-LIMN-081, 0073-LIMN-082, 0073-LIMN-083, 0073-LIMN-084, 0073-LIMN-085, 0073-LIMN-086, 0073-LIMN-087, 0073-LIMN-088, 0073-LIMN-089, 0073-LIMN-090, 0073-LIMN-091, 0073-LIMN-092, 0073-LIMN-093, 0073-LIMN-094, 0073-LIMN-095, 0073-LIMN-096, 0073-LIMN-097, 0073-LIMN-098, 0073-LIMN-099, 0073-LIMN-100, 0074-BTCH-012, 0074-BTCH-015, 0074-BTCH-016, 0074-BTCH-019, 0079-TGAP-006, 0079-TGAP-007, 0080-SPOT-001, 0080-SPOT-002, 0080-SPOT-003, 0080-SPOT-004, 0080-SPOT-006, 0080-SPOT-009, 0080-SPOT-010, 0080-SPOT-012, 0080-SPOT-013, 0080-SPOT-007, 0080-SPOT-015, 0080-SPOT-016, 0080-SPOT-017, 0080-SPOT-018, 0080-SPOT-019, 0080-SPOT-020, 0081-SUCM-004
Uncovered ACs for Ethereum Oracles (deployment-2): 0082-ETHD-001, 0082-ETHD-002, 0082-ETHD-003, 0082-ETHD-004, 0082-ETHD-005, 0082-ETHD-006, 0082-ETHD-007, 0082-ETHD-008, 0082-ETHD-009, 0082-ETHD-010, 0082-ETHD-011, 0082-ETHD-012, 0082-ETHD-013, 0082-ETHD-014, 0082-ETHD-016, 0082-ETHD-017, 0082-ETHD-018, 0082-ETHD-019, 0082-ETHD-020, 0082-ETHD-021, 0082-ETHD-022, 0082-ETHD-023, 0082-ETHD-024, 0082-ETHD-025, 0082-ETHD-026, 0082-ETHD-027, 0082-ETHD-028, 0082-ETHD-029, 0082-ETHD-030, 0082-ETHD-034, 0082-ETHD-035, 0082-ETHD-036, 0082-ETHD-037, 0082-ETHD-038, 0082-ETHD-039, 0082-ETHD-040, 0082-ETHD-041, 0082-ETHD-042, 0082-ETHD-043, 0082-ETHD-044, 0082-ETHD-045
Uncovered ACs for SLA (deployment-2): 0026-AUCT-017, 0026-AUCT-018, 0026-AUCT-019, 0026-AUCT-020, 0026-AUCT-021, 0026-AUCT-022, 0042-LIQF-032, 0042-LIQF-050, 0042-LIQF-051, 0042-LIQF-052, 0042-LIQF-034, 0042-LIQF-049, 0042-LIQF-047, 0042-LIQF-043, 0042-LIQF-044, 0042-LIQF-045, 0042-LIQF-046, 0044-LIME-057, 0044-LIME-058, 0044-LIME-059, 0044-LIME-048, 0044-LIME-046, 0044-LIME-047, 0044-LIME-018, 0044-LIME-019, 0044-LIME-020, 0044-LIME-021, 0044-LIME-030, 0044-LIME-031, 0044-LIME-049, 0044-LIME-022, 0044-LIME-023, 0044-LIME-045, 0044-LIME-024, 0044-LIME-044, 0044-LIME-025, 0044-LIME-043, 0044-LIME-026, 0044-LIME-027, 0044-LIME-050, 0044-LIME-054, 0044-LIME-051, 0044-LIME-055, 0044-LIME-053, 0044-LIME-052, 0044-LIME-056, 0044-LIME-028, 0044-LIME-029, 0044-LIME-032, 0044-LIME-033, 0044-LIME-034, 0044-LIME-035, 0044-LIME-036
Uncovered ACs for Batch change proposals (deployment-2): 0028-GOVE-146, 0028-GOVE-147, 0028-GOVE-148, 0028-GOVE-149, 0028-GOVE-145
Uncovered ACs for Market governance (deployment-2): 0028-GOVE-064, 0028-GOVE-069, 0028-GOVE-070, 0028-GOVE-072, 0028-GOVE-110, 0028-GOVE-113, 0028-GOVE-118, 0028-GOVE-135, 0028-GOVE-136, 0028-GOVE-137, 0028-GOVE-138, 0028-GOVE-139, 0028-GOVE-111, 0028-GOVE-150, 0028-GOVE-151
```

The single line format is there because it makes it easy to filter the output without having to build new functionality in to. Approbation. Enter [grep](https://www.man7.org/linux/man-pages/man1/grep.1.html):

```shell
node ../approbation/bin/approbation.js check-references --specs="{./specs/protocol/**/*.{md,ipynb},./specs/non-protocol-specs/**/*.{md,ipynb}}" --tests="{./system-tests/tests/**/*.py,./vega/core/integration/**/*.{go,feature},./MultisigControl/test/*.js,./vega/core/**/*_test.go}" --ignore="{./spec-internal/protocol/0060*,./specs/non-protocol-specs/{0001-NP*,0002-NP*,0004-NP*,0006-NP*,0007-NP*,0008-NP*,0010-NP*}}" --output-csv --categories="specs/protocol/categories.json" --features="specs/protocol/features.json" --show-branches | grep deployment-1
```

will filter this down to:

```
Output path should be provided with --output if CSV or Jenkins output are enabled. Defaulting to ./results
Uncovered ACs for Governance Transfers (deployment-1): 0028-GOVE-140, 0028-GOVE-141, 0028-GOVE-144, 0028-GOVE-142, 0028-GOVE-143
Uncovered ACs for Iceberg Orders (deployment-1): 0014-ORDT-069
Uncovered ACs for Stop Orders (deployment-1): 0079-TGAP-004, 0079-TGAP-005
Uncovered ACs for Successor Markets (deployment-1): 0001-MKTF-006, 0001-MKTF-007, 0001-MKTF-008, 0028-GOVE-093, 0081-SUCM-003, 0081-SUCM-030, 0081-SUCM-031, 0081-SUCM-032, 0081-SUCM-025, 0081-SUCM-026
│   Governance Transfers │ deployment-1 │  46 │      41 │           0 │         41 │         5 │    89.1% │
│         Iceberg Orders │ deployment-1 │  34 │      33 │          22 │         12 │         1 │    97.1% │
│            Stop Orders │ deployment-1 │  39 │      37 │          30 │          7 │         2 │    94.9% │
│      Successor Markets │ deployment-1 │  40 │      28 │          13 │         17 │        10 │    70.0% │
│                  Total │ deployment-1 │ 159 │     139 │          65 │         77 │        18 │    87.4% │
```

# Development notes
`approbation` is 1.5 years old, and the `features` feature is probably the last thing that should be built on the current codebase. It's pretty clear now that a version 2 is pending, which can make it easier for people to use approbation's basic processing to produce more data. To this end I'm thinking of breaking it up a bit in to inputs, an SQLite database per run, and outputs. 

Right now, each of the commands available on the command line (`check-references`, `check-codes`) are all implemented with a bit of duplication. `check-references` is where most of the action happens - it's the one command that pulls ACs out of spec files, and all the tests, and then tries to see which are referenced and which aren't, in which category and what feature... and it's got *messy*. Adding on a new feature (like pulling in the pytest output to see which tests are running, as well as implemented) becomes hard work. Instead if we write an intermediate database that can be stored as an artifact of a build, then anyone wanting to process or augment the data from each run can do so by taking that file. Currently that's impossible.