### PR TITLE
chore: update the milestone names

### DIFF
--- a/src/check-references.js
+++ b/src/check-references.js
@@ -368,9 +368,9 @@ function checkReferences(specsGlob, testsGlob, categoriesPath, ignoreGlob, featu
       })
 
       const t = new Table()
-      t.addRows(milestones.get('deployment-1'));
-      t.addRows(milestones.get('deployment-2'));
-      t.addRows(milestones.get('deployment-3'));
+      t.addRows(milestones.get('cosmic-elevator-1'));
+      t.addRows(milestones.get('cosmic-elevator-2'));
+      t.addRows(milestones.get('plazzo'));
       t.addRows([{ Feature: '---', Milestone: '---', acs: '---', Covered: '---', 'by/FeatTest': '---', 'by/SysTest': '---', Uncovered: '---', Coverage: '---' }]);
       t.addRows(totals);
       const tableOutput = t.render()


### PR DESCRIPTION
Since changing the milestone names in the features.json file in the specs repo in [this PR](https://github.com/vegaprotocol/specs/pull/1929) the approbation pipeline has been failing. 

This PR updates the names to match the features.json file in the specs repo.