### PR TITLE
fix: revert last change in PR 119

### DIFF
--- a/src/check-references.js
+++ b/src/check-references.js
@@ -368,9 +368,9 @@ function checkReferences(specsGlob, testsGlob, categoriesPath, ignoreGlob, featu
       })
 
       const t = new Table()
-      t.addRows(milestones.get('cosmic-elevator-1'));
-      t.addRows(milestones.get('cosmic-elevator-2'));
-      t.addRows(milestones.get('plazzo'));
+      t.addRows(milestones.get('deployment-1'));
+      t.addRows(milestones.get('deployment-2'));
+      t.addRows(milestones.get('deployment-3'));
       t.addRows([{ Feature: '---', Milestone: '---', acs: '---', Covered: '---', 'by/FeatTest': '---', 'by/SysTest': '---', Uncovered: '---', Coverage: '---' }]);
       t.addRows(totals);
       const tableOutput = t.render()


### PR DESCRIPTION
reverts the changes made in  https://github.com/vegaprotocol/approbation/pull/119

A specs PR will also be merged to revert the names back to what they were.