### PR TITLE
fix: milestone name change breaks output

### DIFF
--- a/src/check-references.js
+++ b/src/check-references.js
@@ -348,6 +348,8 @@ function checkReferences(specsGlob, testsGlob, categoriesPath, ignoreGlob, featu
 
       })
 
+      const t = new Table()
+
       milestones.forEach((featuresByMilestone, milestoneKey) => {
         if (milestoneKey === 'unknown') {
           return
@@ -365,12 +367,11 @@ function checkReferences(specsGlob, testsGlob, categoriesPath, ignoreGlob, featu
           Uncovered: featuresByMilestone.reduce((acc, cur) => acc + cur.Uncovered, 0) || '-',
           Coverage
         })
+
+        t.addRows(featuresByMilestone);
       })
 
-      const t = new Table()
-      t.addRows(milestones.get('deployment-1'));
-      t.addRows(milestones.get('deployment-2'));
-      t.addRows(milestones.get('deployment-3'));
+
       t.addRows([{ Feature: '---', Milestone: '---', acs: '---', Covered: '---', 'by/FeatTest': '---', 'by/SysTest': '---', Uncovered: '---', Coverage: '---' }]);
       t.addRows(totals);
       const tableOutput = t.render()


### PR DESCRIPTION
Removes hardcoded output filters for milestone names

The table will now look morre like:
<img width="876" alt="Screenshot 2023-11-03 at 12 20 02" src="https://github.com/vegaprotocol/approbation/assets/6678/19df1fd3-dbf7-4347-a1fd-5358c795a7fe">

Closes #124 
