### PR TITLE
chore: update the output of the slack stats to show milestone coverage

### DIFF
--- a/src/check-references.js
+++ b/src/check-references.js
@@ -426,7 +426,8 @@ function checkReferences(specsGlob, testsGlob, categoriesPath, ignoreGlob, featu
 
         if (shouldOutputJenkins) {
           const skipCategories = ['Category', 'Specs', 'Acceptable']
-          const jenkinsLine = Object.entries(categories.pop()).map(([key, value]) => skipCategories.indexOf(key) === -1 ? `*${key}*: ${value}` : '').join('  ').trim()
+          let jenkinsLine = `All ACs: \r\n ${Object.entries(categories.pop()).map(([key, value]) => skipCategories.indexOf(key) === -1 ? `*${key}*: ${value}` : '').join('  ').trim()} \r\n`
+          jenkinsLine += `Current milestone ACs: \r\n ${Object.entries(milestones.pop()).map(([key, value]) => skipCategories.indexOf(key) === -1 ? `*${key}*: ${value}` : '').join('  ').trim()}`
           fs.writeFileSync(`${outputPath}/jenkins.txt`, jenkinsLine)
         }
 


### PR DESCRIPTION
This updates the Jenkins output for slack to show both overall AC coverage stats and the current milestone stats.

The intended output is like this:

All ACs:
Criteria: 2386  Covered: 1790  by/FeatTest: 565  by/SysTest: 1160  Uncovered: 596  Coverage: 75.0% 
Current milestone ACs:
Criteria: 100  Covered: 99  by/FeatTest: 98  by/SysTest: 1  Uncovered: 1  Coverage: 99.0%